### PR TITLE
Switch order of `coords` and `v`

### DIFF
--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -15,9 +15,9 @@
 #'  in each fold.
 #'
 #' @param data A data frame.
-#' @param v The number of partitions of the data set.
 #' @param coords A vector of variable names, typically spatial coordinates,
 #'  to partition the data into disjointed sets via k-means clustering.
+#' @param v The number of partitions of the data set.
 #' @param ... Extra arguments passed on to [stats::kmeans()].
 #' @export
 #' @return A tibble with classes `spatial_cv`, `rset`, `tbl_df`, `tbl`, and
@@ -33,10 +33,10 @@
 #'
 #' @examples
 #' data(ames, package = "modeldata")
-#' spatial_clustering_cv(ames, v = 5, coords = c(Latitude, Longitude))
+#' spatial_clustering_cv(ames, coords = c(Latitude, Longitude), v = 5)
 #'
 #' @export
-spatial_clustering_cv <- function(data, v = 10, coords, ...) {
+spatial_clustering_cv <- function(data, coords, v = 10,  ...) {
 
     coords <- tidyselect::eval_select(rlang::enquo(coords), data = data)
 
@@ -44,7 +44,7 @@ spatial_clustering_cv <- function(data, v = 10, coords, ...) {
         rlang::abort("`coords` are required and must be variables in `data`.")
     }
 
-    split_objs <- spatial_clustering_splits(data = data, v = v, coords = coords, ...)
+    split_objs <- spatial_clustering_splits(data = data, coords = coords, v = v,  ...)
 
     ## We remove the holdout indices since it will save space and we can
     ## derive them later when they are needed.
@@ -61,7 +61,7 @@ spatial_clustering_cv <- function(data, v = 10, coords, ...) {
              subclass = c("spatial_clustering_cv", "rset"))
 }
 
-spatial_clustering_splits <- function(data, v = 10, coords, ...) {
+spatial_clustering_splits <- function(data, coords, v = 10, ...) {
 
     if (!is.numeric(v) || length(v) != 1)
         rlang::abort("`v` must be a single integer.")

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,9 +18,10 @@ theme_set(theme_minimal())
 # spatialsample
 
 <!-- badges: start -->
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+[![CRAN status](https://www.r-pkg.org/badges/version/spatialsample)](https://CRAN.R-project.org/package=spatialsample)
 [![R-CMD-check](https://github.com/tidymodels/spatialsample/workflows/R-CMD-check/badge.svg)](https://github.com/tidymodels/spatialsample/actions)
 [![Codecov test coverage](https://codecov.io/gh/tidymodels/spatialsample/branch/master/graph/badge.svg)](https://codecov.io/gh/tidymodels/spatialsample?branch=master)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 <!-- badges: end -->
 
 ## Introduction
@@ -56,7 +57,7 @@ library(spatialsample)
 data("ames", package = "modeldata")
 
 set.seed(1234)
-folds <- spatial_clustering_cv(ames, v = 5, coords = c("Latitude", "Longitude"))
+folds <- spatial_clustering_cv(ames, coords = c("Latitude", "Longitude"), v = 5)
 
 folds
 ```

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 <!-- badges: start -->
 
-[![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/spatialsample)](https://CRAN.R-project.org/package=spatialsample)
 [![R-CMD-check](https://github.com/tidymodels/spatialsample/workflows/R-CMD-check/badge.svg)](https://github.com/tidymodels/spatialsample/actions)
 [![Codecov test
 coverage](https://codecov.io/gh/tidymodels/spatialsample/branch/master/graph/badge.svg)](https://codecov.io/gh/tidymodels/spatialsample?branch=master)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
 <!-- badges: end -->
 
 ## Introduction
@@ -56,17 +58,18 @@ library(spatialsample)
 data("ames", package = "modeldata")
 
 set.seed(1234)
-folds <- spatial_clustering_cv(ames, v = 5, coords = c("Latitude", "Longitude"))
+folds <- spatial_clustering_cv(ames, coords = c("Latitude", "Longitude"), v = 5)
 
 folds
+#> #  5-fold spatial cross-validation 
 #> # A tibble: 5 x 2
 #>   splits             id   
 #>   <list>             <chr>
-#> 1 <split [2.3K/598]> Fold1
-#> 2 <split [2.2K/743]> Fold2
-#> 3 <split [2.6K/360]> Fold3
-#> 4 <split [2.1K/812]> Fold4
-#> 5 <split [2.5K/417]> Fold5
+#> 1 <split [2332/598]> Fold1
+#> 2 <split [2187/743]> Fold2
+#> 3 <split [2570/360]> Fold3
+#> 4 <split [2118/812]> Fold4
+#> 5 <split [2513/417]> Fold5
 ```
 
 In this example, the `ames` data on houses in Ames, IA is resampled with

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -4,15 +4,15 @@
 \alias{spatial_clustering_cv}
 \title{Spatial or Cluster Cross-Validation}
 \usage{
-spatial_clustering_cv(data, v = 10, coords, ...)
+spatial_clustering_cv(data, coords, v = 10, ...)
 }
 \arguments{
 \item{data}{A data frame.}
 
-\item{v}{The number of partitions of the data set.}
-
 \item{coords}{A vector of variable names, typically spatial coordinates,
 to partition the data into disjointed sets via k-means clustering.}
+
+\item{v}{The number of partitions of the data set.}
 
 \item{...}{Extra arguments passed on to \code{\link[stats:kmeans]{stats::kmeans()}}.}
 }
@@ -38,7 +38,7 @@ in each fold.
 }
 \examples{
 data(ames, package = "modeldata")
-spatial_clustering_cv(ames, v = 5, coords = c(Latitude, Longitude))
+spatial_clustering_cv(ames, coords = c(Latitude, Longitude), v = 5)
 
 }
 \references{

--- a/tests/testthat/helper-rset.R
+++ b/tests/testthat/helper-rset.R
@@ -9,7 +9,7 @@ test_data <- function() {
 
 # Keep this list up to date with known rset subclasses for testing.
 rset_subclasses <- list(
-    spatial_clustering_cv = spatial_clustering_cv(test_data(), v = 3, coords = c(x, y))
+    spatial_clustering_cv = spatial_clustering_cv(test_data(), coords = c(x, y), v = 3)
 )
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -8,8 +8,9 @@ data("Smithsonian")
 
 test_that('default param', {
     set.seed(11)
-    rs1 <- spatial_clustering_cv(Smithsonian, v = 2,
-                                 coords = c(latitude, longitude))
+    rs1 <- spatial_clustering_cv(Smithsonian,
+                                 coords = c(latitude, longitude),
+                                 v = 2)
     sizes1 <- dim_rset(rs1)
 
     expect_true(all(sizes1$analysis + sizes1$assessment == 20))
@@ -32,20 +33,23 @@ test_that('bad args', {
 })
 
 test_that('can pass the dots to kmeans', {
-    expect_error(spatial_clustering_cv(Smithsonian, v = 2,
-                                       coords = c(latitude, longitude), algorithm = "MacQueen"),
+    expect_error(spatial_clustering_cv(Smithsonian,
+                                       coords = c(latitude, longitude),
+                                       v = 2,
+                                       algorithm = "MacQueen"),
                  NA)
 })
 
 test_that('printing', {
     expect_snapshot_output(
-        spatial_clustering_cv(Smithsonian, v = 2,
-                              coords = c(latitude, longitude))
+        spatial_clustering_cv(Smithsonian,
+                              coords = c(latitude, longitude),
+                              v = 2)
     )
 })
 
 test_that('rsplit labels', {
-    rs <- spatial_clustering_cv(Smithsonian, v = 2, coords = c(latitude, longitude))
+    rs <- spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 2)
     all_labs <- map_df(rs$splits, labels)
     original_id <- rs[, grepl("^id", names(rs))]
     expect_equal(all_labs, original_id)

--- a/vignettes/spatialsample.Rmd
+++ b/vignettes/spatialsample.Rmd
@@ -34,7 +34,7 @@ This relationship may exhibit spatial autocorrelation across the city of Ames, a
 library(spatialsample)
 
 set.seed(123)
-folds <- spatial_clustering_cv(ames, v = 15, coords = c("Latitude", "Longitude"))
+folds <- spatial_clustering_cv(ames, coords = c("Latitude", "Longitude"), v = 15)
 folds
 ```
 


### PR DESCRIPTION
Closes #5 

This PR reverse the order of `coords` and `v` so that we can now do this:

``` r
library(spatialsample)
data("Smithsonian", package = "modeldata")

spatial_clustering_cv(Smithsonian, c(latitude, longitude))
#> #  10-fold spatial cross-validation 
#> # A tibble: 10 x 2
#>    splits         id    
#>    <list>         <chr> 
#>  1 <split [16/4]> Fold01
#>  2 <split [18/2]> Fold02
#>  3 <split [18/2]> Fold03
#>  4 <split [19/1]> Fold04
#>  5 <split [18/2]> Fold05
#>  6 <split [18/2]> Fold06
#>  7 <split [19/1]> Fold07
#>  8 <split [19/1]> Fold08
#>  9 <split [18/2]> Fold09
#> 10 <split [17/3]> Fold10
```

<sup>Created on 2021-02-25 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>