### PR TITLE
Wrap all.equal to fail on failures

### DIFF
--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -24,7 +24,7 @@ test_that("using kmeans", {
   expect_true(all(sizes1$analysis + sizes1$assessment == 20))
   same_data <-
     map_lgl(rs1$splits, function(x) {
-      all.equal(x$data, Smithsonian)
+      isTRUE(all.equal(x$data, Smithsonian))
     })
   expect_true(all(same_data))
 
@@ -50,7 +50,7 @@ test_that("using hclust", {
     expect_true(all(sizes1$analysis + sizes1$assessment == 20))
     same_data <-
         map_lgl(rs1$splits, function(x) {
-            all.equal(x$data, Smithsonian)
+            isTRUE(all.equal(x$data, Smithsonian))
         })
     expect_true(all(same_data))
 
@@ -108,7 +108,7 @@ test_that("using sf", {
   expect_true(all(sizes1$analysis + sizes1$assessment == 20))
   same_data <-
     map_lgl(rs1$splits, function(x) {
-      all.equal(x$data, Smithsonian_sf)
+      isTRUE(all.equal(x$data, Smithsonian_sf))
     })
   expect_true(all(same_data))
 


### PR DESCRIPTION
Tiny PR to wrap `all.equal` in `isTRUE` so that `map_lgl` doesn't error -- this way we'll catch the error in `expect_true` and get an easier-to-track test failure should things go wrong.

``` r
library(modeldata)
library(spatialsample)
library(purrr)
data("Smithsonian")
set.seed(11)

rs1 <- spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 2)

map_lgl(rs1$splits, function(x) all.equal(x$data, "Not TRUE"))
#> Error in `stop_bad_type()`:
#> ! Result 1 must be a single logical, not a character vector of length 8

map_lgl(rs1$splits, function(x) isTRUE(all.equal(x$data, "Not TRUE")))
#> [1] FALSE FALSE
```

<sup>Created on 2022-05-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>