### PR TITLE
Allow custom clustering functions (#16)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
   specifies what type of clustering to perform. `cluster_function = "kmeans"`, 
   the default, uses `stats::kmeans()` for k-means clustering, while 
   `cluster_function = "hclust"` uses `stats::hclust()` for hierarchical 
-  clustering.
+  clustering. Users can also provide their own clustering function.
   
 * `spatial_clustering_cv()` now supports `sf` objects! Coordinates are inferred
   automatically when using `sf` objects, and anything passed to `coords` will

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -21,7 +21,9 @@
 #' the number of folds to create, and `...`. Both the `dist` object and `v`
 #' are passed by position, without names, and must be the first and second
 #' arguments to your function respectively; any named arguments to your
-#' function can be accessed via `...`.
+#' function can be accessed via `...`. The function should return a vector
+#' of cluster assignments of length `nrow(data)`, with each element of the
+#' vector corresponding to the matching row of the data frame.
 #'
 #' @param data A data frame or an `sf` object (often from [sf::read_sf()]
 #' or [sf::st_as_sf()]), to split into folds.

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -16,12 +16,14 @@
 #'  in each fold.
 #'
 #' You can optionally provide a custom function to `cluster_function`. The
-#' function must take three arguments: `dists`, a [stats::dist()] object
-#' indicating distances between data points, `v`, a length-1 numeric indicating
-#' the number of folds to create, and `...`. Any additional named arguments to
-#' your function can be accessed via `...`. The function should return a vector
-#' of cluster assignments of length `nrow(data)`, with each element of the
-#' vector corresponding to the matching row of the data frame.
+#' function must take three arguments:
+#' - `dists`, a [stats::dist()] object with distances between data points
+#' - `v`, a length-1 numeric for the number of folds to create
+#' - `...`, to pass any additional named arguments to your function
+#'
+#' The function should return a vector of cluster assignments of length
+#' `nrow(data)`, with each element of the vector corresponding to the matching
+#' row of the data frame.
 #'
 #' @param data A data frame or an `sf` object (often from [sf::read_sf()]
 #' or [sf::st_as_sf()]), to split into folds.
@@ -29,7 +31,7 @@
 #'  to partition the data into disjointed sets via k-means clustering.
 #'  This argument is ignored (with a warning) if `data` is an `sf` object.
 #' @param v The number of partitions of the data set.
-#' @param cluster_function Which function to use for clustering.
+#' @param cluster_function Which function should be used for clustering?
 #' Options are either `"kmeans"` (to use [stats::kmeans()])
 #' or `"hclust"` (to use [stats::hclust()]). You can also provide your own
 #' function; see `Details`.

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -16,12 +16,10 @@
 #'  in each fold.
 #'
 #' You can optionally provide a custom function to `cluster_function`. The
-#' function must take three arguments in a set order: a [stats::dist()] object
-#' indicating distances between data points, a length-1 numeric `v` indicating
-#' the number of folds to create, and `...`. Both the `dist` object and `v`
-#' are passed by position, without names, and must be the first and second
-#' arguments to your function respectively; any named arguments to your
-#' function can be accessed via `...`. The function should return a vector
+#' function must take three arguments: `dists`, a [stats::dist()] object
+#' indicating distances between data points, `v`, a length-1 numeric indicating
+#' the number of folds to create, and `...`. Any additional named arguments to
+#' your function can be accessed via `...`. The function should return a vector
 #' of cluster assignments of length `nrow(data)`, with each element of the
 #' vector corresponding to the matching row of the data frame.
 #'
@@ -136,7 +134,7 @@ spatial_clustering_splits <- function(data, dists, v = 10, cluster_function = c(
       clusters <- hclust(dists, ...)
       cutree(clusters, k = v)
     },
-    do.call(cluster_function, list(dists, v, ...))
+    do.call(cluster_function, list(dists = dists, v = v, ...))
   )
 
   idx <- seq_len(n)

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -30,9 +30,9 @@
 #'  This argument is ignored (with a warning) if `data` is an `sf` object.
 #' @param v The number of partitions of the data set.
 #' @param cluster_function Which function to use for clustering.
-#' Options are either "kmeans" (to use [stats::kmeans()])
-#' or "hclust" (to use [stats::hclust()]). You can also provide your own
-#' function; see `details`.
+#' Options are either `"kmeans"` (to use [stats::kmeans()])
+#' or `"hclust"` (to use [stats::hclust()]). You can also provide your own
+#' function; see `Details`.
 #' @param ... Extra arguments passed on to [stats::kmeans()] or
 #' [stats::hclust()].
 #'

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -22,10 +22,10 @@ This argument is ignored (with a warning) if \code{data} is an \code{sf} object.
 
 \item{v}{The number of partitions of the data set.}
 
-\item{cluster_function}{Which function to use for clustering.
-Options are either "kmeans" (to use \code{\link[stats:kmeans]{stats::kmeans()}})
-or "hclust" (to use \code{\link[stats:hclust]{stats::hclust()}}). You can also provide your own
-function; see \code{details}.}
+\item{cluster_function}{Which function should be used for clustering?
+Options are either \code{"kmeans"} (to use \code{\link[stats:kmeans]{stats::kmeans()}})
+or \code{"hclust"} (to use \code{\link[stats:hclust]{stats::hclust()}}). You can also provide your own
+function; see \code{Details}.}
 
 \item{...}{Extra arguments passed on to \code{\link[stats:kmeans]{stats::kmeans()}} or
 \code{\link[stats:hclust]{stats::hclust()}}.}
@@ -52,12 +52,16 @@ data are distributed spatially, there may not be an equal number of points
 in each fold.
 
 You can optionally provide a custom function to \code{cluster_function}. The
-function must take three arguments: \code{dists}, a \code{\link[stats:dist]{stats::dist()}} object
-indicating distances between data points, \code{v}, a length-1 numeric indicating
-the number of folds to create, and \code{...}. Any additional named arguments to
-your function can be accessed via \code{...}. The function should return a vector
-of cluster assignments of length \code{nrow(data)}, with each element of the
-vector corresponding to the matching row of the data frame.
+function must take three arguments:
+\itemize{
+\item \code{dists}, a \code{\link[stats:dist]{stats::dist()}} object with distances between data points
+\item \code{v}, a length-1 numeric for the number of folds to create
+\item \code{...}, to pass any additional named arguments to your function
+}
+
+The function should return a vector of cluster assignments of length
+\code{nrow(data)}, with each element of the vector corresponding to the matching
+row of the data frame.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -22,8 +22,10 @@ This argument is ignored (with a warning) if \code{data} is an \code{sf} object.
 
 \item{v}{The number of partitions of the data set.}
 
-\item{cluster_function}{Which function to use for clustering. Must be one of either
-"kmeans" (to use \code{\link[stats:kmeans]{stats::kmeans()}}) or "hclust" (to use \code{\link[stats:hclust]{stats::hclust()}}).}
+\item{cluster_function}{Which function to use for clustering.
+Options are either "kmeans" (to use \code{\link[stats:kmeans]{stats::kmeans()}})
+or "hclust" (to use \code{\link[stats:hclust]{stats::hclust()}}). You can also provide your own
+function; see \code{details}.}
 
 \item{...}{Extra arguments passed on to \code{\link[stats:kmeans]{stats::kmeans()}} or
 \code{\link[stats:hclust]{stats::hclust()}}.}
@@ -48,6 +50,16 @@ hierarchical clustering of the data. These
 clusters are used as the folds for cross-validation. Depending on how the
 data are distributed spatially, there may not be an equal number of points
 in each fold.
+
+You can optionally provide a custom function to \code{cluster_function}. The
+function must take three arguments in a set order: a \code{\link[stats:dist]{stats::dist()}} object
+indicating distances between data points, a length-1 numeric \code{v} indicating
+the number of folds to create, and \code{...}. Both the \code{dist} object and \code{v}
+are passed by position, without names, and must be the first and second
+arguments to your function respectively; any named arguments to your
+function can be accessed via \code{...}. The function should return a vector
+of cluster assignments of length \code{nrow(data)}, with each element of the
+vector corresponding to the matching row of the data frame.
 }
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -52,12 +52,10 @@ data are distributed spatially, there may not be an equal number of points
 in each fold.
 
 You can optionally provide a custom function to \code{cluster_function}. The
-function must take three arguments in a set order: a \code{\link[stats:dist]{stats::dist()}} object
-indicating distances between data points, a length-1 numeric \code{v} indicating
-the number of folds to create, and \code{...}. Both the \code{dist} object and \code{v}
-are passed by position, without names, and must be the first and second
-arguments to your function respectively; any named arguments to your
-function can be accessed via \code{...}. The function should return a vector
+function must take three arguments: \code{dists}, a \code{\link[stats:dist]{stats::dist()}} object
+indicating distances between data points, \code{v}, a length-1 numeric indicating
+the number of folds to create, and \code{...}. Any additional named arguments to
+your function can be accessed via \code{...}. The function should return a vector
 of cluster assignments of length \code{nrow(data)}, with each element of the
 vector corresponding to the matching row of the data frame.
 }

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -93,7 +93,6 @@ test_that("can pass the dots to kmeans", {
 
 test_that("using sf", {
 
-
   Smithsonian_sf <- sf::st_as_sf(Smithsonian,
                                  coords = c("longitude", "latitude"),
                                  crs = 4326)
@@ -140,6 +139,55 @@ test_that("using sf", {
 
 
 })
+
+test_that("using custom functions", {
+
+  custom_cluster <- function(dists, v, ...) {
+    clusters <- kmeans(dists, centers = v, ...)
+    letters[clusters$cluster]
+  }
+
+  set.seed(11)
+  rs1 <- spatial_clustering_cv(Smithsonian,
+                               coords = c(latitude, longitude),
+                               v = 2
+  )
+  set.seed(11)
+  rs2 <- spatial_clustering_cv(Smithsonian,
+                               coords = c(latitude, longitude),
+                               v = 2,
+                               cluster_function = custom_cluster
+  )
+  expect_identical(rs1, rs2)
+
+  expect_error(
+    spatial_clustering_cv(Smithsonian,
+                          coords = c(latitude, longitude),
+                          v = 2,
+                          cluster_function = custom_cluster,
+                          algorithm = "MacQueen"
+    ),
+    NA
+  )
+
+  Smithsonian_sf <- sf::st_as_sf(Smithsonian,
+                                 coords = c("longitude", "latitude"),
+                                 crs = 4326)
+
+  expect_error(
+    spatial_clustering_cv(Smithsonian_sf,
+                          v = 2,
+                          cluster_function = custom_cluster,
+                          algorithm = "MacQueen"
+    ),
+    NA
+  )
+
+
+})
+
+
+
 
 test_that("printing", {
   # The default RNG changed in 3.6.0

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -148,37 +148,42 @@ test_that("using custom functions", {
   }
 
   set.seed(11)
-  rs1 <- spatial_clustering_cv(Smithsonian,
-                               coords = c(latitude, longitude),
-                               v = 2
+  rs1 <- spatial_clustering_cv(
+    Smithsonian,
+    coords = c(latitude, longitude),
+    v = 2
   )
   set.seed(11)
-  rs2 <- spatial_clustering_cv(Smithsonian,
-                               coords = c(latitude, longitude),
-                               v = 2,
-                               cluster_function = custom_cluster
+  rs2 <- spatial_clustering_cv(
+    Smithsonian,
+    coords = c(latitude, longitude),
+    v = 2,
+    cluster_function = custom_cluster
   )
   expect_identical(rs1, rs2)
 
   expect_error(
-    spatial_clustering_cv(Smithsonian,
-                          coords = c(latitude, longitude),
-                          v = 2,
-                          cluster_function = custom_cluster,
-                          algorithm = "MacQueen"
+    spatial_clustering_cv(
+      Smithsonian,
+      coords = c(latitude, longitude),
+      v = 2,
+      cluster_function = custom_cluster,
+      algorithm = "MacQueen"
     ),
     NA
   )
 
-  Smithsonian_sf <- sf::st_as_sf(Smithsonian,
-                                 coords = c("longitude", "latitude"),
-                                 crs = 4326)
+  Smithsonian_sf <- sf::st_as_sf(
+    Smithsonian,
+    coords = c("longitude", "latitude"),
+    crs = 4326)
 
   expect_error(
-    spatial_clustering_cv(Smithsonian_sf,
-                          v = 2,
-                          cluster_function = custom_cluster,
-                          algorithm = "MacQueen"
+    spatial_clustering_cv(
+      Smithsonian_sf,
+      v = 2,
+      cluster_function = custom_cluster,
+      algorithm = "MacQueen"
     ),
     NA
   )


### PR DESCRIPTION
This is my attempt to prove that I _can_ do a small PR :laughing: 

Following #16, this PR allows users to provide their own custom clustering functions to `spatial_clustering_cv()`:

``` r
library(spatialsample)
data(ames, package = "modeldata")

custom_cluster <- function(dists, v, ...) {
  clusters <- kmeans(dists, centers = v, ...)
  letters[clusters$cluster]
}

set.seed(11)
rs1 <- spatial_clustering_cv(ames,
                             coords = c(Latitude, Longitude),
                             v = 2
)
set.seed(11)
rs2 <- spatial_clustering_cv(ames,
                             coords = c(Latitude, Longitude),
                             v = 2,
                             cluster_function = custom_cluster
)
identical(rs1, rs1)
#> [1] TRUE
```

<sup>Created on 2022-05-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I don't think this precludes us from supporting other cluster methods directly (as we do `kmeans` and `hclust`) in the future, but it does open up using a lot of alternative clustering methods in other packages without requiring us to import them directly.