### PR TITLE
Refine use of `glue::glue()`

### DIFF
--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -157,9 +157,9 @@ systematic_block_cv <- function(data, grid_blocks, v,
   if (num_folds != v) {
     rlang::warn(c(
       "Not all folds contained blocks with data:",
-      i = glue::glue("{v} folds were requested, \\
+      x = glue::glue("{v} folds were requested, \\
                      but only {num_folds} contain any data."),
-      i = "Empty folds were dropped.",
+      x = "Empty folds were dropped.",
       i = "To avoid this, set `relevant_only = TRUE`."
     ))
     v <- num_folds

--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -155,19 +155,13 @@ systematic_block_cv <- function(data, grid_blocks, v,
 
   num_folds <- length(unique(grid_blocks$fold))
   if (num_folds != v) {
-    rlang::warn(
-      c(
-        glue::glue(
-          "Not all folds contained blocks with data: \n{v} folds were",
-          "requested, but only {num_folds} contain any data.",
-          "\nEmpty folds were dropped.",
-          v = v,
-          num_folds = num_folds,
-          .sep = " "
-        ),
-        i = "To avoid this, set `relevant_only = TRUE`."
-      )
-    )
+    rlang::warn(c(
+      "Not all folds contained blocks with data:",
+      i = glue::glue("{v} folds were requested, \\
+                       but only {num_folds} contain any data."),
+      i = "Empty folds were dropped.",
+      i = "To avoid this, set `relevant_only = TRUE`."
+    ))
     v <- num_folds
   }
 

--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -158,7 +158,7 @@ systematic_block_cv <- function(data, grid_blocks, v,
     rlang::warn(c(
       "Not all folds contained blocks with data:",
       i = glue::glue("{v} folds were requested, \\
-                       but only {num_folds} contain any data."),
+                     but only {num_folds} contain any data."),
       i = "Empty folds were dropped.",
       i = "To avoid this, set `relevant_only = TRUE`."
     ))

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -39,8 +39,8 @@
     Condition
       Warning:
       Not all folds contained blocks with data:
-      i 5 folds were requested, but only 4 contain any data.
-      i Empty folds were dropped.
+      x 5 folds were requested, but only 4 contain any data.
+      x Empty folds were dropped.
       i To avoid this, set `relevant_only = TRUE`.
     Output
       #  4-fold spatial block cross-validation 

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -38,9 +38,9 @@
       spatial_block_cv(ames_sf, method = "snake", relevant_only = FALSE, v = 5)
     Condition
       Warning:
-      Not all folds contained blocks with data: 
-      5 folds were requested, but only 4 contain any data. 
-      Empty folds were dropped.
+      Not all folds contained blocks with data:
+      i 5 folds were requested, but only 4 contain any data.
+      i Empty folds were dropped.
       i To avoid this, set `relevant_only = TRUE`.
     Output
       #  4-fold spatial block cross-validation 


### PR DESCRIPTION
@mikemahoney218 This is a more typical way we use the glue functions. (Note the use of `\\`, interpolated strings, etc.)