### PR TITLE
Reformat code

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -12,8 +12,11 @@
 #'
 #' @examplesIf rlang::is_installed("ggplot2") && rlang::is_installed("modeldata")
 #' data(ames, package = "modeldata")
-#' ames_sf <- sf::st_as_sf(ames,
-#'                         coords = c("Longitude", "Latitude"), crs = 4326)
+#' ames_sf <- sf::st_as_sf(
+#'   ames,
+#'   coords = c("Longitude", "Latitude"),
+#'   crs = 4326
+#' )
 #'
 #' ames_block <- spatial_block_cv(ames_sf)
 #' autoplot(ames_block)
@@ -29,9 +32,10 @@ autoplot.spatial_rset <- function(object, ...) {
     ~ cbind(assessment(.x), fold = .y)
   )
 
-  p <- ggplot2::ggplot(data = object,
-                       mapping = ggplot2::aes(color = fold, fill = fold))
+  p <- ggplot2::ggplot(
+    data = object,
+    mapping = ggplot2::aes(color = fold, fill = fold)
+  )
   p <- p + ggplot2::geom_sf(...)
   p + ggplot2::coord_sf()
-
 }

--- a/R/labels.R
+++ b/R/labels.R
@@ -8,9 +8,11 @@ pretty.spatial_clustering_cv <- function(x, ...) {
 #' @export
 print.spatial_clustering_cv <- function(x, ...) {
   cat("# ", pretty(x), "\n")
-  class(x) <- class(x)[!(class(x) %in% c("spatial_clustering_cv",
-                                         "spatial_rset",
-                                         "rset"))]
+  class(x) <- class(x)[!(class(x) %in% c(
+    "spatial_clustering_cv",
+    "spatial_rset",
+    "rset"
+  ))]
   print(x, ...)
 }
 
@@ -24,8 +26,10 @@ pretty.spatial_block_cv <- function(x, ...) {
 #' @export
 print.spatial_block_cv <- function(x, ...) {
   cat("# ", pretty(x), "\n")
-  class(x) <- class(x)[!(class(x) %in% c("spatial_block_cv",
-                                         "spatial_rset",
-                                         "rset"))]
+  class(x) <- class(x)[!(class(x) %in% c(
+    "spatial_block_cv",
+    "spatial_rset",
+    "rset"
+  ))]
   print(x, ...)
 }

--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -42,10 +42,12 @@
 #'
 #' @examplesIf rlang::is_installed("modeldata")
 #' data(Smithsonian, package = "modeldata")
-#' smithsonian_sf <- sf::st_as_sf(Smithsonian,
-#'                                coords = c("longitude", "latitude"),
-#'                                # Set CRS to WGS84
-#'                                crs = 4326)
+#' smithsonian_sf <- sf::st_as_sf(
+#'   Smithsonian,
+#'   coords = c("longitude", "latitude"),
+#'   # Set CRS to WGS84
+#'   crs = 4326
+#' )
 #'
 #' spatial_block_cv(smithsonian_sf, v = 3)
 #'
@@ -118,7 +120,6 @@ spatial_block_cv <- function(data,
     attrib = cv_att,
     subclass = c("spatial_block_cv", "spatial_rset", "rset")
   )
-
 }
 
 random_block_cv <- function(data, grid_blocks, v) {
@@ -135,7 +136,9 @@ random_block_cv <- function(data, grid_blocks, v) {
   generate_folds_from_blocks(data, grid_blocks, v, n)
 }
 
-systematic_block_cv <- function(data, grid_blocks, v,
+systematic_block_cv <- function(data,
+                                grid_blocks,
+                                v,
                                 ordering = c("snake", "continuous"),
                                 relevant_only = TRUE) {
   n <- nrow(data)
@@ -235,11 +238,13 @@ row_ids_intersecting_fold_blocks <- function(grid_blocks, data) {
   # to the row numbers that intersect with blocks in the fold
   purrr::map(
     grid_blocks,
-    function(blocks) which(
-      purrr::map_lgl(
-        sf::st_intersects(data, blocks),
-        sgbp_is_not_empty
+    function(blocks) {
+      which(
+        purrr::map_lgl(
+          sf::st_intersects(data, blocks),
+          sgbp_is_not_empty
+        )
       )
-    )
+    }
   )
 }

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -53,10 +53,12 @@
 #' data(Smithsonian, package = "modeldata")
 #' spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 5)
 #'
-#' smithsonian_sf <- sf::st_as_sf(Smithsonian,
-#'                                coords = c("longitude", "latitude"),
-#'                                # Set CRS to WGS84
-#'                                crs = 4326)
+#' smithsonian_sf <- sf::st_as_sf(
+#'   Smithsonian,
+#'   coords = c("longitude", "latitude"),
+#'   # Set CRS to WGS84
+#'   crs = 4326
+#' )
 #'
 #' # When providing sf objects, coords are inferred automatically
 #' spatial_clustering_cv(smithsonian_sf, v = 5)
@@ -88,11 +90,13 @@ spatial_clustering_cv <- function(data, coords, v = 10, cluster_function = c("km
     subclasses <- setdiff(subclasses, "spatial_rset")
   }
 
-  split_objs <- spatial_clustering_splits(data = data,
-                                          dists = dists,
-                                          v = v,
-                                          cluster_function = cluster_function,
-                                          ...)
+  split_objs <- spatial_clustering_splits(
+    data = data,
+    dists = dists,
+    v = v,
+    cluster_function = cluster_function,
+    ...
+  )
 
   ## We remove the holdout indices since it will save space and we can
   ## derive them later when they are needed.
@@ -109,11 +113,13 @@ spatial_clustering_cv <- function(data, coords, v = 10, cluster_function = c("km
     attrib = cv_att,
     subclass = subclasses
   )
-
 }
 
-spatial_clustering_splits <- function(data, dists, v = 10, cluster_function = c("kmeans", "hclust"), ...) {
-
+spatial_clustering_splits <- function(data,
+                                      dists,
+                                      v = 10,
+                                      cluster_function = c("kmeans", "hclust"),
+                                      ...) {
   if (!rlang::is_function(cluster_function)) {
     cluster_function <- rlang::arg_match(cluster_function)
   }
@@ -122,9 +128,11 @@ spatial_clustering_splits <- function(data, dists, v = 10, cluster_function = c(
 
   n <- nrow(data)
 
-  clusterer <- ifelse(rlang::is_function(cluster_function),
-                      "custom",
-                      cluster_function)
+  clusterer <- ifelse(
+    rlang::is_function(cluster_function),
+    "custom",
+    cluster_function
+  )
 
   folds <- switch(
     clusterer,

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -38,9 +38,12 @@
 #' @param ... Extra arguments passed on to [stats::kmeans()] or
 #' [stats::hclust()].
 #'
-#' @return A tibble with classes `spatial_cv`, `rset`, `tbl_df`, `tbl`, and
-#'  `data.frame`. The results include a column for the data split objects and
+#' @return A tibble with classes `spatial_clustering_cv`, `spatial_rset`,
+#'  `rset`, `tbl_df`, `tbl`, and `data.frame`.
+#'  The results include a column for the data split objects and
 #'  an identification variable `id`.
+#'  Resamples created from non-`sf` objects will not have the
+#'  `spatial_rset` class.
 #'
 #' @references
 #'

--- a/data-raw/boston_canopy.R
+++ b/data-raw/boston_canopy.R
@@ -7,20 +7,26 @@ download.file(
   file.path(working_dir, "canopy_metrics.zip")
 )
 
-unzip(file.path(working_dir, "canopy_metrics.zip"),
-      exdir = working_dir)
+unzip(
+  file.path(working_dir, "canopy_metrics.zip"),
+  exdir = working_dir
+)
 
 download.file(
   "https://bostonopendata-boston.opendata.arcgis.com/datasets/boston::hex-mean-heat-index.zip?outSR=%7B%22latestWkid%22%3A2249%2C%22wkid%22%3A102686%7D",
   file.path(working_dir, "heat_metrics.zip")
 )
 
-unzip(file.path(working_dir, "heat_metrics.zip"),
-      exdir = working_dir)
+unzip(
+  file.path(working_dir, "heat_metrics.zip"),
+  exdir = working_dir
+)
 
 boston_canopy <- sf::read_sf(
-  file.path(working_dir,
-            "Canopy_Change_Assessment%3A_Tree_Canopy_Change_Metrics.shp")
+  file.path(
+    working_dir,
+    "Canopy_Change_Assessment%3A_Tree_Canopy_Change_Metrics.shp"
+  )
 )
 
 canopy_metrics <- c(
@@ -43,8 +49,10 @@ boston_canopy <- boston_canopy[canopy_metrics]
 names(boston_canopy) <- names(canopy_metrics)
 
 heat <- sf::read_sf(
-  file.path(working_dir,
-            "Canopy_Change_Assessment%3A_Heat_Metrics.shp")
+  file.path(
+    working_dir,
+    "Canopy_Change_Assessment%3A_Heat_Metrics.shp"
+  )
 )
 
 heat_metrics <- c(

--- a/man/autoplot.spatial_rset.Rd
+++ b/man/autoplot.spatial_rset.Rd
@@ -23,8 +23,11 @@ This method provides a good visualization method for spatial resampling.
 \examples{
 \dontshow{if (rlang::is_installed("ggplot2") && rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data(ames, package = "modeldata")
-ames_sf <- sf::st_as_sf(ames,
-                        coords = c("Longitude", "Latitude"), crs = 4326)
+ames_sf <- sf::st_as_sf(
+  ames,
+  coords = c("Longitude", "Latitude"),
+  crs = 4326
+)
 
 ames_block <- spatial_block_cv(ames_sf)
 autoplot(ames_block)

--- a/man/spatial_block_cv.Rd
+++ b/man/spatial_block_cv.Rd
@@ -62,10 +62,12 @@ number of cells.
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data(Smithsonian, package = "modeldata")
-smithsonian_sf <- sf::st_as_sf(Smithsonian,
-                               coords = c("longitude", "latitude"),
-                               # Set CRS to WGS84
-                               crs = 4326)
+smithsonian_sf <- sf::st_as_sf(
+  Smithsonian,
+  coords = c("longitude", "latitude"),
+  # Set CRS to WGS84
+  crs = 4326
+)
 
 spatial_block_cv(smithsonian_sf, v = 3)
 \dontshow{\}) # examplesIf}

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -31,9 +31,12 @@ function; see \code{Details}.}
 \code{\link[stats:hclust]{stats::hclust()}}.}
 }
 \value{
-A tibble with classes \code{spatial_cv}, \code{rset}, \code{tbl_df}, \code{tbl}, and
-\code{data.frame}. The results include a column for the data split objects and
+A tibble with classes \code{spatial_clustering_cv}, \code{spatial_rset},
+\code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}.
+The results include a column for the data split objects and
 an identification variable \code{id}.
+Resamples created from non-\code{sf} objects will not have the
+\code{spatial_rset} class.
 }
 \description{
 Spatial or cluster cross-validation splits the data into V groups of

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -68,10 +68,12 @@ row of the data frame.
 data(Smithsonian, package = "modeldata")
 spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 5)
 
-smithsonian_sf <- sf::st_as_sf(Smithsonian,
-                               coords = c("longitude", "latitude"),
-                               # Set CRS to WGS84
-                               crs = 4326)
+smithsonian_sf <- sf::st_as_sf(
+  Smithsonian,
+  coords = c("longitude", "latitude"),
+  # Set CRS to WGS84
+  crs = 4326
+)
 
 # When providing sf objects, coords are inferred automatically
 spatial_clustering_cv(smithsonian_sf, v = 5)

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -14,7 +14,6 @@ set.seed(123)
 ames_non_sf <- spatial_clustering_cv(ames, coords = c("Longitude", "Latitude"))
 
 test_that("autoplot is stable", {
-
   p <- autoplot(ames_cluster)
   vdiffr::expect_doppelganger("cluster plots", p)
 
@@ -25,5 +24,4 @@ test_that("autoplot is stable", {
     autoplot(ames_non_sf),
     error = TRUE
   )
-
 })

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -17,10 +17,12 @@ test_that("random assignment", {
   expect_identical(rs1, rs2)
 
   expect_true(all(sizes1$analysis + sizes1$assessment == nrow(ames)))
-  same_data <-
-    map_lgl(rs1$splits, function(x) {
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
       isTRUE(all.equal(x$data, ames_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -37,10 +39,12 @@ test_that("systematic assignment -- snake", {
   rs1 <- spatial_block_cv(ames_sf, method = "snake")
   sizes1 <- dim_rset(rs1)
   expect_true(all(sizes1$analysis + sizes1$assessment == nrow(ames)))
-  same_data <-
-    map_lgl(rs1$splits, function(x) {
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
       isTRUE(all.equal(x$data, ames_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -52,16 +56,20 @@ test_that("systematic assignment -- snake", {
   expect_true(all(good_holdout))
 
   set.seed(123)
-  rs3 <- spatial_block_cv(ames_sf,
-                          method = "snake",
-                          relevant_only = FALSE,
-                          v = 4)
+  rs3 <- spatial_block_cv(
+    ames_sf,
+    method = "snake",
+    relevant_only = FALSE,
+    v = 4
+  )
   sizes3 <- dim_rset(rs3)
   expect_true(all(sizes3$analysis + sizes3$assessment == nrow(ames)))
-  same_data <-
-    map_lgl(rs3$splits, function(x) {
+  same_data <- map_lgl(
+    rs3$splits,
+    function(x) {
       isTRUE(all.equal(x$data, ames_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -71,7 +79,6 @@ test_that("systematic assignment -- snake", {
     }
   )
   expect_true(all(good_holdout))
-
 })
 
 test_that("systematic assignment -- continuous", {
@@ -80,10 +87,12 @@ test_that("systematic assignment -- continuous", {
 
   sizes1 <- dim_rset(rs1)
   expect_true(all(sizes1$analysis + sizes1$assessment == nrow(ames)))
-  same_data <-
-    map_lgl(rs1$splits, function(x) {
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
       isTRUE(all.equal(x$data, ames_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -96,15 +105,18 @@ test_that("systematic assignment -- continuous", {
 
   set.seed(123)
   rs3 <- spatial_block_cv(ames_sf,
-                          method = "continuous",
-                          relevant_only = FALSE,
-                          v = 4)
+    method = "continuous",
+    relevant_only = FALSE,
+    v = 4
+  )
   sizes3 <- dim_rset(rs3)
   expect_true(all(sizes3$analysis + sizes3$assessment == nrow(ames)))
-  same_data <-
-    map_lgl(rs3$splits, function(x) {
+  same_data <- map_lgl(
+    rs3$splits,
+    function(x) {
       isTRUE(all.equal(x$data, ames_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -117,7 +129,6 @@ test_that("systematic assignment -- continuous", {
 })
 
 test_that("bad args", {
-
   set.seed(123)
   expect_snapshot(
     spatial_block_cv(ames),
@@ -160,7 +171,6 @@ test_that("bad args", {
   expect_snapshot(
     spatial_block_cv(ames_sf, v = 60)
   )
-
 })
 
 test_that("printing", {

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -7,24 +7,28 @@ data("Smithsonian", package = "modeldata")
 
 test_that("using kmeans", {
   set.seed(11)
-  rs1 <- spatial_clustering_cv(Smithsonian,
+  rs1 <- spatial_clustering_cv(
+    Smithsonian,
     coords = c(latitude, longitude),
     v = 2
   )
   set.seed(11)
-  rs2 <- spatial_clustering_cv(Smithsonian,
-                               coords = c(latitude, longitude),
-                               v = 2,
-                               cluster_function = "kmeans"
+  rs2 <- spatial_clustering_cv(
+    Smithsonian,
+    coords = c(latitude, longitude),
+    v = 2,
+    cluster_function = "kmeans"
   )
   expect_identical(rs1, rs2)
   sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis + sizes1$assessment == 20))
-  same_data <-
-    map_lgl(rs1$splits, function(x) {
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
       isTRUE(all.equal(x$data, Smithsonian))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -38,44 +42,53 @@ test_that("using kmeans", {
 
 
 test_that("using hclust", {
-    set.seed(11)
-    rs1 <- spatial_clustering_cv(Smithsonian,
-                                 coords = c(latitude, longitude),
-                                 v = 2,
-                                 cluster_function = "hclust"
-    )
-    sizes1 <- dim_rset(rs1)
+  set.seed(11)
+  rs1 <- spatial_clustering_cv(
+    Smithsonian,
+    coords = c(latitude, longitude),
+    v = 2,
+    cluster_function = "hclust"
+  )
+  sizes1 <- dim_rset(rs1)
 
-    expect_true(all(sizes1$analysis + sizes1$assessment == 20))
-    same_data <-
-        map_lgl(rs1$splits, function(x) {
-            isTRUE(all.equal(x$data, Smithsonian))
-        })
-    expect_true(all(same_data))
+  expect_true(all(sizes1$analysis + sizes1$assessment == 20))
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
+      isTRUE(all.equal(x$data, Smithsonian))
+    }
+  )
+  expect_true(all(same_data))
 
-    good_holdout <- map_lgl(
-        rs1$splits,
-        function(x) {
-            length(intersect(x$in_ind, x$out_id)) == 0
-        }
-    )
-    expect_true(all(good_holdout))
+  good_holdout <- map_lgl(
+    rs1$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
 })
 
 
 test_that("bad args", {
   expect_error(spatial_clustering_cv(Smithsonian, coords = NULL))
-  expect_error(spatial_clustering_cv(Smithsonian, coords = c(Species, Sepal.Width)))
+  expect_error(
+    spatial_clustering_cv(Smithsonian, coords = c(Species, Sepal.Width))
+  )
   expect_snapshot(
-    spatial_clustering_cv(Smithsonian,
-                          coords = c(latitude, longitude),
-                          v = "a"),
+    spatial_clustering_cv(
+      Smithsonian,
+      coords = c(latitude, longitude),
+      v = "a"
+    ),
     error = TRUE
   )
   expect_snapshot(
-    spatial_clustering_cv(Smithsonian,
-                          coords = c(latitude, longitude),
-                          v = c(5, 10)),
+    spatial_clustering_cv(
+      Smithsonian,
+      coords = c(latitude, longitude),
+      v = c(5, 10)
+    ),
     error = TRUE
   )
 })
@@ -93,22 +106,26 @@ test_that("can pass the dots to kmeans", {
 })
 
 test_that("using sf", {
-
-  Smithsonian_sf <- sf::st_as_sf(Smithsonian,
-                                 coords = c("longitude", "latitude"),
-                                 crs = 4326)
+  Smithsonian_sf <- sf::st_as_sf(
+    Smithsonian,
+    coords = c("longitude", "latitude"),
+    crs = 4326
+  )
 
   set.seed(11)
-  rs1 <- spatial_clustering_cv(Smithsonian_sf,
-                               v = 2
+  rs1 <- spatial_clustering_cv(
+    Smithsonian_sf,
+    v = 2
   )
   sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis + sizes1$assessment == 20))
-  same_data <-
-    map_lgl(rs1$splits, function(x) {
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
       isTRUE(all.equal(x$data, Smithsonian_sf))
-    })
+    }
+  )
   expect_true(all(same_data))
 
   good_holdout <- map_lgl(
@@ -137,12 +154,9 @@ test_that("using sf", {
   expect_snapshot(
     spatial_clustering_cv(Smithsonian_sf, coords = c(latitude, longitude))
   )
-
-
 })
 
 test_that("using custom functions", {
-
   custom_cluster <- function(dists, v, ...) {
     clusters <- kmeans(dists, centers = v, ...)
     letters[clusters$cluster]
@@ -177,7 +191,8 @@ test_that("using custom functions", {
   Smithsonian_sf <- sf::st_as_sf(
     Smithsonian,
     coords = c("longitude", "latitude"),
-    crs = 4326)
+    crs = 4326
+  )
 
   expect_error(
     spatial_clustering_cv(
@@ -188,8 +203,6 @@ test_that("using custom functions", {
     ),
     NA
   )
-
-
 })
 
 
@@ -201,8 +214,8 @@ test_that("printing", {
   set.seed(123)
   expect_snapshot_output(
     spatial_clustering_cv(Smithsonian,
-                          coords = c(latitude, longitude),
-                          v = 2
+      coords = c(latitude, longitude),
+      v = 2
     )
   )
 })


### PR DESCRIPTION
This PR reformats code following #34, ensuring that code is styled to be more in line with the tidyverse style guide. I ran an initial pass of `styler` before manually scanning code to try and catch all instances of the issye mentioned as #34.

It also, for no reason other than this being a general "tidyness" PR, fixes the documentation mentioned in #26. 