### PR TITLE
Test in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ VignetteBuilder:
 Config/Needs/website: 
     tidyverse/tidytemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Re #40 , this PR would start running our tests in parallel. Running against the current state of #39, this brought the test suite runtime down from 82.5s single-threaded to 45.2s with two threads on my machine. I didn't get any test failures with parallel enabled, though I'm not sure if that's a guarantee that the tests are parallel-safe. 