### PR TITLE
Spruce up check_v

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -35,8 +35,8 @@ check_v <- function(v,
                     objects,
                     allow_max_v = TRUE,
                     call = rlang::caller_env()) {
-  if (!is.numeric(v) || length(v) != 1) {
-    rlang::abort("`v` must be a single integer.", call = call)
+  if (!is.numeric(v) || length(v) != 1 || v < 1) {
+    rlang::abort("`v` must be a single positive integer.", call = call)
   }
 
   if (v > max_v) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -30,15 +30,40 @@ split_unnamed <- function(x, f) {
 }
 
 ### Functions below are spatialsample-specific
-check_v <- function(v, max_v, objects, call = rlang::caller_env()) {
+check_v <- function(v,
+                    max_v,
+                    objects,
+                    allow_max_v = TRUE,
+                    call = rlang::caller_env()) {
   if (!is.numeric(v) || length(v) != 1) {
     rlang::abort("`v` must be a single integer.", call = call)
   }
   if (v > max_v) {
-    rlang::warn(paste0(
-      "Fewer than ", v, " ", objects, " available for sampling; setting v to ",
-      max_v, "."
-    ), call = call)
+
+    if (!allow_max_v) {
+      rlang::abort(
+        c(
+          glue::glue(
+            "The number of {objects} is less than `v = {v}` ({max_v})"
+          ),
+          i = "Set `v` to a smaller value than {max_v}"
+        ),
+        call = call
+      )
+    }
+
+    rlang::warn(
+      c(
+        glue::glue(
+          "Fewer than {v} {objects} available for sampling",
+        ),
+        i = glue::glue(
+          "Setting `v` to {max_v}",
+        )
+      ),
+      call = call
+    )
+
     v <- max_v
   }
   v

--- a/R/misc.R
+++ b/R/misc.R
@@ -38,8 +38,8 @@ check_v <- function(v,
   if (!is.numeric(v) || length(v) != 1) {
     rlang::abort("`v` must be a single integer.", call = call)
   }
-  if (v > max_v) {
 
+  if (v > max_v) {
     if (!allow_max_v) {
       rlang::abort(
         c(
@@ -54,12 +54,8 @@ check_v <- function(v,
 
     rlang::warn(
       c(
-        glue::glue(
-          "Fewer than {v} {objects} available for sampling",
-        ),
-        i = glue::glue(
-          "Setting `v` to {max_v}",
-        )
+        glue::glue("Fewer than {v} {objects} available for sampling"),
+        i = glue::glue("Setting `v` to {max_v}")
       ),
       call = call
     )

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -127,7 +127,7 @@ spatial_clustering_splits <- function(data,
     cluster_function <- rlang::arg_match(cluster_function)
   }
 
-  v <- check_v(v, nrow(data), "data points")
+  v <- check_v(v, nrow(data), "data points", allow_max_v = FALSE)
 
   classes <- c("spatial_clustering_split")
   if ("sf" %in% class(data)) classes <- c(classes, "spatial_rsplit")

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -1,0 +1,42 @@
+# check_v errors appropriately
+
+    Code
+      check_v(-1)
+    Condition
+      Error:
+      ! `v` must be a single positive integer.
+
+---
+
+    Code
+      check_v(c(5, 10))
+    Condition
+      Error:
+      ! `v` must be a single positive integer.
+
+---
+
+    Code
+      check_v("a")
+    Condition
+      Error:
+      ! `v` must be a single positive integer.
+
+---
+
+    Code
+      check_v(10, 5, "rows", FALSE)
+    Condition
+      Error:
+      ! The number of rows is less than `v = 10` (5)
+      i Set `v` to a smaller value than {max_v}
+
+# check_v updates v appropriately
+
+    Code
+      new_v <- check_v(10, 5, "rows")
+    Condition
+      Warning:
+      Fewer than 10 rows available for sampling
+      i Setting `v` to 5
+

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -22,7 +22,7 @@
       spatial_block_cv(ames_sf, v = c(5, 10))
     Condition
       Error in `spatial_block_cv()`:
-      ! `v` must be a single integer.
+      ! `v` must be a single positive integer.
 
 ---
 
@@ -30,7 +30,7 @@
       spatial_block_cv(ames_sf, v = c(5, 10), method = "snake")
     Condition
       Error in `spatial_block_cv()`:
-      ! `v` must be a single integer.
+      ! `v` must be a single positive integer.
 
 ---
 

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -58,7 +58,8 @@
       spatial_block_cv(ames_sf, method = "snake", v = 60)
     Condition
       Warning in `spatial_block_cv()`:
-      Fewer than 60 blocks available for sampling; setting v to 17.
+      Fewer than 60 blocks available for sampling
+      i Setting `v` to 17
     Output
       #  17-fold spatial block cross-validation 
       # A tibble: 17 x 2
@@ -88,7 +89,8 @@
       spatial_block_cv(ames_sf, v = 60)
     Condition
       Warning in `spatial_block_cv()`:
-      Fewer than 60 blocks available for sampling; setting v to 17.
+      Fewer than 60 blocks available for sampling
+      i Setting `v` to 17
     Output
       #  17-fold spatial block cross-validation 
       # A tibble: 17 x 2

--- a/tests/testthat/_snaps/spatial_clustering_cv.md
+++ b/tests/testthat/_snaps/spatial_clustering_cv.md
@@ -4,7 +4,7 @@
       spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = "a")
     Condition
       Error in `spatial_clustering_splits()`:
-      ! `v` must be a single integer.
+      ! `v` must be a single positive integer.
 
 ---
 
@@ -12,7 +12,7 @@
       spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = c(5, 10))
     Condition
       Error in `spatial_clustering_splits()`:
-      ! `v` must be a single integer.
+      ! `v` must be a single positive integer.
 
 ---
 

--- a/tests/testthat/_snaps/spatial_clustering_cv.md
+++ b/tests/testthat/_snaps/spatial_clustering_cv.md
@@ -14,6 +14,15 @@
       Error in `spatial_clustering_splits()`:
       ! `v` must be a single integer.
 
+---
+
+    Code
+      spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 100)
+    Condition
+      Error in `spatial_clustering_splits()`:
+      ! The number of data points is less than `v = 100` (20)
+      i Set `v` to a smaller value than {max_v}
+
 # using sf
 
     Code

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,0 +1,30 @@
+test_that("check_v errors appropriately", {
+  expect_snapshot(
+    check_v(-1),
+    error = TRUE
+  )
+  expect_snapshot(
+    check_v(c(5, 10)),
+    error = TRUE
+  )
+  expect_snapshot(
+    check_v("a"),
+    error = TRUE
+  )
+  expect_snapshot(
+    check_v(10, 5, "rows", FALSE),
+    error = TRUE
+  )
+})
+
+test_that("check_v updates v appropriately", {
+
+  expect_snapshot(
+    new_v <- check_v(10, 5, "rows")
+  )
+
+  expect_identical(
+    new_v,
+    5
+  )
+})

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -91,6 +91,14 @@ test_that("bad args", {
     ),
     error = TRUE
   )
+  expect_snapshot(
+    spatial_clustering_cv(
+      Smithsonian,
+      coords = c(latitude, longitude),
+      v = 100
+    ),
+    error = TRUE
+  )
 })
 
 test_that("can pass the dots to kmeans", {


### PR DESCRIPTION
Inspired by https://github.com/tidymodels/rsample/pull/293 , this PR:

* updates check_v to use `glue`
* adds a flag `allow_max_v` which lets the function error if setting `v` to `max_v` wouldn't make sense