### PR TITLE
Use centroids

### DIFF
--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -177,7 +177,10 @@ systematic_block_cv <- function(data,
 generate_folds_from_blocks <- function(data, grid_blocks, v, n) {
   grid_blocks <- split_unnamed(grid_blocks, grid_blocks$fold)
 
-  indices <- row_ids_intersecting_fold_blocks(grid_blocks, data)
+  centroids <- sf::st_geometry(data)
+  centroids <- sf::st_centroid(centroids)
+
+  indices <- row_ids_intersecting_fold_blocks(grid_blocks, centroids)
 
   indices <- lapply(indices, default_complement, n = n)
   split_objs <- purrr::map(

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -128,6 +128,42 @@ test_that("systematic assignment -- continuous", {
   expect_true(all(good_holdout))
 })
 
+test_that("polygons are only assigned one fold", {
+  set.seed(11)
+
+  rs1 <- spatial_block_cv(boston_canopy, method = "continuous")
+  rs2 <- spatial_block_cv(boston_canopy, method = "snake")
+  rs3 <- spatial_block_cv(boston_canopy, method = "random")
+
+  expect_identical(
+    sum(map_int(rs1$splits, function(x) nrow(assessment(x)))),
+    nrow(boston_canopy)
+  )
+
+  expect_identical(
+    sum(map_int(rs2$splits, function(x) nrow(assessment(x)))),
+    nrow(boston_canopy)
+  )
+
+  expect_identical(
+    sum(map_int(rs3$splits, function(x) nrow(assessment(x)))),
+    nrow(boston_canopy)
+  )
+
+  good_holdout <- map_lgl(
+    c(
+      rs1$splits,
+      rs2$splits,
+      rs3$splits
+    ),
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+
+})
+
 test_that("bad args", {
   set.seed(123)
   expect_snapshot(

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -213,8 +213,34 @@ test_that("using custom functions", {
   )
 })
 
+test_that("polygons are only assigned one fold", {
+  set.seed(11)
 
+  rs1 <- spatial_clustering_cv(boston_canopy, cluster_function = "hclust")
+  rs2 <- spatial_clustering_cv(boston_canopy, cluster_function = "kmeans")
 
+  expect_identical(
+    sum(map_int(rs1$splits, function(x) nrow(assessment(x)))),
+    nrow(boston_canopy)
+  )
+
+  expect_identical(
+    sum(map_int(rs2$splits, function(x) nrow(assessment(x)))),
+    nrow(boston_canopy)
+  )
+
+  good_holdout <- map_lgl(
+    c(
+      rs1$splits,
+      rs2$splits
+    ),
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+
+})
 
 test_that("printing", {
   # The default RNG changed in 3.6.0


### PR DESCRIPTION
This PR fixes #43 by using centroids when assigning data to blocks, meaning that polygons will only be assigned to one block. It also fixes #29 by using our projected non-point data set for testing.