### PR TITLE
Let buffer handle units (fixes #52)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Imports:
     sf,
     tibble,
     tidyselect,
+    units,
     vctrs (>= 0.3.6)
 Suggests: 
     covr,
@@ -41,7 +42,6 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     tidyr,
-    units,
     vdiffr,
     yardstick
 VignetteBuilder: 

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -36,7 +36,7 @@ buffer_indices <- function(data, indices, radius, buffer, call = rlang::caller_e
 
   # only run radius checks if radius is not NULL (to prevent NAs from >)
   run_radius <- !is.null(radius)
-  if (run_radius && radius > 0) {
+  if (run_radius && units::set_units(radius, NULL) > 0) {
     indices <- row_ids_within_dist(data, indices, radius)
   }
 
@@ -56,7 +56,7 @@ buffered_complement <- function(ind, buff_ind, n) {
 }
 
 row_ids_within_dist <- function(data, indices, dist) {
-  if (dist > 0) {
+  if (units::set_units(dist, NULL) > 0) {
     purrr::map(
       # indices is the output of split_unnamed
       indices,

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -255,6 +255,11 @@ test_that("using buffers", {
 })
 
 test_that("buffers respect units", {
+
+  skip_if_not(sf::sf_use_s2())
+  skip_if_offline()
+  sf::sf_proj_network(enable = TRUE)
+
   set.seed(123)
   rs1 <- spatial_block_cv(
     boston_canopy,

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -253,3 +253,46 @@ test_that("using buffers", {
   )
 
 })
+
+test_that("buffers respect units", {
+  set.seed(123)
+  rs1 <- spatial_block_cv(
+    boston_canopy,
+    v = 2,
+    method = "snake",
+    radius = 500,
+    buffer = 500
+  )
+  set.seed(123)
+  rs2 <- spatial_block_cv(
+    boston_canopy,
+    v = 2,
+    method = "snake",
+    radius = units::as_units(500, "ft"),
+    buffer = units::as_units(500, "ft")
+  )
+  attr(rs2, "radius") <- 500
+  attr(rs2, "buffer") <- 500
+  expect_identical(rs1, rs2)
+
+  set.seed(123)
+  rs1 <- spatial_block_cv(
+    ames_sf,
+    v = 2,
+    method = "snake",
+    radius = 500,
+    buffer = 500
+  )
+  set.seed(123)
+  rs2 <- spatial_block_cv(
+    ames_sf,
+    v = 2,
+    method = "snake",
+    radius = units::as_units(500, "m"),
+    buffer = units::as_units(500, "m")
+  )
+  attr(rs2, "radius") <- 500
+  attr(rs2, "buffer") <- 500
+  expect_identical(rs1, rs2)
+
+})


### PR DESCRIPTION
This PR fixes #52 by making sure we don't use `units` objects for any conditionals. It also adds test cases using units objects to ensure this keeps working moving forward.