### PR TITLE
Pass group and strata as curly

### DIFF
--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -85,7 +85,7 @@ spatial_buffer_vfold_cv <- function(data,
     data = data,
     v = v,
     repeats = repeats,
-    strata = strata,
+    strata = {{ strata }},
     breaks = breaks,
     pool = pool,
     ...

--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -146,7 +146,7 @@ spatial_leave_location_out_cv <- function(data,
   rset <- rsample::group_vfold_cv(
     data = data,
     v = v,
-    group = group,
+    group = {{ group }},
     ...
   )
 

--- a/tests/testthat/_snaps/buffer.md
+++ b/tests/testthat/_snaps/buffer.md
@@ -44,8 +44,7 @@
 ---
 
     Code
-      suppressMessages(spatial_buffer_vfold_cv(boston_canopy, v = 682, radius = 500,
-        buffer = 500))
+      spatial_buffer_vfold_cv(boston_canopy, v = 682, radius = 500, buffer = 500)
     Output
       #  682-fold spatial cross-validation 
       # A tibble: 682 x 2
@@ -66,8 +65,8 @@
 ---
 
     Code
-      suppressMessages(spatial_leave_location_out_cv(ames_sf, Neighborhood, v = 682,
-        radius = 500, buffer = 500))
+      spatial_leave_location_out_cv(ames_sf, Neighborhood, v = 682, radius = 500,
+        buffer = 500)
     Condition
       Warning in `spatial_leave_location_out_cv()`:
       Fewer than 682 locations available for sampling

--- a/tests/testthat/_snaps/spatial_vfold_cv.md
+++ b/tests/testthat/_snaps/spatial_vfold_cv.md
@@ -1,7 +1,7 @@
 # erroring when no S2
 
     Code
-      suppressMessages(spatial_buffer_vfold_cv(ames_sf, buffer = 500, radius = NULL))
+      spatial_buffer_vfold_cv(ames_sf, buffer = 500, radius = NULL)
     Condition
       Error in `spatial_buffer_vfold_cv()`:
       ! `buffer` and `radius` can only be used with geographic coordinates when using the s2 geometry library

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -242,35 +242,24 @@ test_that("using buffers", {
   # The default RNG changed in 3.6.0
   skip_if_not(getRversion() >= numeric_version("3.6.0"))
 
-  # suppressMessages to avoid:
-  # + "Message"
-  # + "  Note: Using an external vector in selections is ambiguous."
-  # + "  i Use `all_of(group)` instead of `group` to silence this message."
-  # + "  i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>."
-  # + "  This message is displayed once per session."
-  # This is percolating up from rsample but I can't find where https://github.com/tidymodels/rsample/runs/6760867450?check_suite_focus=true#step:6:182
   set.seed(11)
   expect_snapshot(
-    suppressMessages(
-      spatial_buffer_vfold_cv(
-        boston_canopy,
-        v = 682,
-        radius = 500,
-        buffer = 500
-      )
+    spatial_buffer_vfold_cv(
+      boston_canopy,
+      v = 682,
+      radius = 500,
+      buffer = 500
     )
   )
 
   set.seed(11)
   expect_snapshot(
-    suppressMessages(
-      spatial_leave_location_out_cv(
-        ames_sf,
-        Neighborhood,
-        v = 682,
-        radius = 500,
-        buffer = 500
-      )
+    spatial_leave_location_out_cv(
+      ames_sf,
+      Neighborhood,
+      v = 682,
+      radius = 500,
+      buffer = 500
     )
   )
 

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -10,16 +10,8 @@ ames_sf <- sf::st_as_sf(ames, coords = c("Longitude", "Latitude"), crs = 4326)
 test_that("erroring when no S2", {
   s2_store <- sf::sf_use_s2()
   sf::sf_use_s2(FALSE)
-
-  # suppressMessages to avoid:
-  # + "Message"
-  # + "  Note: Using an external vector in selections is ambiguous."
-  # + "  i Use `all_of(group)` instead of `group` to silence this message."
-  # + "  i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>."
-  # + "  This message is displayed once per session."
-  # This is percolating up from rsample but I can't find where https://github.com/tidymodels/rsample/runs/6760867450?check_suite_focus=true#step:6:182
   expect_snapshot(
-    suppressMessages(spatial_buffer_vfold_cv(ames_sf, buffer = 500, radius = NULL)),
+    spatial_buffer_vfold_cv(ames_sf, buffer = 500, radius = NULL),
     error = TRUE
   )
   expect_snapshot(


### PR DESCRIPTION
Inspired by Julia's sleuthing here: https://github.com/tidymodels/rsample/pull/296 , I _believe_ this lets us take away the suppressMessage calls we had in tests by not trying to evaluate `group` or `strata` twice. 