### PR TITLE
Capitalize 'fold'

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -35,26 +35,31 @@
 # registered in zzz.R
 #' @export
 autoplot.spatial_rset <- function(object, ..., alpha = 0.6) {
-  fold <- NULL
+  # .fold. is named to not interfere with normal column names
+  .fold. <- NULL
 
   object <- purrr::map2_dfr(
     object$splits,
     object$id,
-    ~ cbind(assessment(.x), fold = .y)
+    ~ cbind(assessment(.x), .fold. = .y)
   )
 
   p <- ggplot2::ggplot(
     data = object,
-    mapping = ggplot2::aes(color = fold, fill = fold)
+    mapping = ggplot2::aes(color = .fold., fill = .fold.)
   )
   p <- p + ggplot2::geom_sf(..., alpha = alpha)
+  p <- p + ggplot2::guides(
+    colour = ggplot2::guide_legend("Fold"),
+    fill = ggplot2::guide_legend("Fold")
+  )
   p + ggplot2::coord_sf()
 }
 
 #' @export
 autoplot.spatial_rsplit <- function(object, ..., alpha = 0.6) {
-  # .Class. is named to not interfere with normal column names
-  .Class. <- NULL
+  # .class. is named to not interfere with normal column names
+  .class. <- NULL
 
   ins <- object$in_id
   outs <- if (identical(object$out_id, NA)) {
@@ -63,15 +68,17 @@ autoplot.spatial_rsplit <- function(object, ..., alpha = 0.6) {
     object$out_id
   }
   object <- object$data
-  object$.Class. <- NA
-  object$.Class.[ins] <- "Analysis"
-  object$.Class.[outs] <- "Assessment"
-  object$.Class.[is.na(object$.Class.)] <- "Buffer"
+  object$.class. <- NA
+  object$.class.[ins] <- "Analysis"
+  object$.class.[outs] <- "Assessment"
+  object$.class.[is.na(object$.class.)] <- "Buffer"
 
   p <- ggplot2::ggplot(data = object,
-                       mapping = ggplot2::aes(color = .Class., fill = .Class.))
-  p <- p + ggplot2::scale_fill_discrete(name = "Class")
-  p <- p + ggplot2::scale_color_discrete(name = "Class")
+                       mapping = ggplot2::aes(color = .class., fill = .class.))
+  p <- p + ggplot2::guides(
+    colour = ggplot2::guide_legend("Class"),
+    fill = ggplot2::guide_legend("Class")
+  )
   p <- p + ggplot2::geom_sf(..., alpha = alpha)
   p + ggplot2::coord_sf()
 }

--- a/tests/testthat/_snaps/autoplot/block-plots-with-grid.svg
+++ b/tests/testthat/_snaps/autoplot/block-plots-with-grid.svg
@@ -3064,7 +3064,7 @@
 <text x='610.08' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='613.39' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='659.45' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='659.45' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='659.45' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='659.45' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='220.06' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-opacity: 0.60; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='660.16' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: square; stroke-linejoin: miter;' />

--- a/tests/testthat/_snaps/autoplot/block-plots.svg
+++ b/tests/testthat/_snaps/autoplot/block-plots.svg
@@ -3010,7 +3010,7 @@
 <text x='612.88' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='616.19' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='657.90' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='657.90' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='657.90' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='657.90' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='666.54' cy='220.06' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-opacity: 0.60; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='657.90' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot/buffered-llo-set-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-llo-set-plot.svg
@@ -3010,7 +3010,7 @@
 <text x='567.40' y='550.17' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='570.71' y='550.17' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='609.71' y='161.53' width='104.81' height='257.25' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='609.71' y='170.24' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='609.71' y='170.24' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='609.71' y='176.86' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='618.35' cy='185.50' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-opacity: 0.60; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='609.71' y='194.14' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot/buffered-rset-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-rset-plot.svg
@@ -883,7 +883,7 @@
 <text x='578.00' y='562.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='581.31' y='562.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='664.85' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: square; stroke-linejoin: miter;' />

--- a/tests/testthat/_snaps/autoplot/buffered-vfold-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-vfold-plot.svg
@@ -822,7 +822,7 @@
 <text x='578.00' y='562.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='581.31' y='562.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='664.85' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='664.85' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot/cluster-plots.svg
+++ b/tests/testthat/_snaps/autoplot/cluster-plots.svg
@@ -3010,7 +3010,7 @@
 <text x='612.88' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='3.31px' lengthAdjust='spacingAndGlyphs'>°</text>
 <text x='616.19' y='568.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.31px' lengthAdjust='spacingAndGlyphs'>W</text>
 <rect x='657.90' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='657.90' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='17.73px' lengthAdjust='spacingAndGlyphs'>fold</text>
+<text x='657.90' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='657.90' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='666.54' cy='220.06' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-opacity: 0.60; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='657.90' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />


### PR DESCRIPTION
`Fold` is now capitalized in ggplot2 legends, to match `Class`. I also made a few other changes to make the two autoplot methods match each other.