### PR TITLE
Inform if few blocks used (fixes #67)

### DIFF
--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -104,6 +104,7 @@ spatial_block_cv <- function(data,
   }
 
   grid_blocks <- sf::st_make_grid(grid_box, ...)
+  original_number_of_blocks <- length(grid_blocks)
   split_objs <- switch(
     method,
     "random" = random_block_cv(
@@ -125,6 +126,20 @@ spatial_block_cv <- function(data,
       buffer = buffer
     )
   )
+
+  percent_used <- split_objs$filtered_number_of_blocks[[1]] / original_number_of_blocks
+
+  if (percent_used < 0.1) {
+    percent_used <- round(percent_used * 100, 2)
+    rlang::inform(
+      c(
+        glue::glue("Only {percent_used}% of blocks contained any data"),
+        i = "Check to make sure your block sizes make sense for your data"
+      )
+    )
+  }
+  split_objs$filtered_number_of_blocks <- NULL
+
   v <- split_objs$v[[1]]
   split_objs$v <- NULL
 
@@ -210,6 +225,7 @@ systematic_block_cv <- function(data,
 }
 
 generate_folds_from_blocks <- function(data, centroids, grid_blocks, v, n, radius, buffer) {
+  filtered_number_of_blocks <- nrow(grid_blocks)
   grid_blocks <- split_unnamed(grid_blocks, grid_blocks$fold)
 
   indices <- row_ids_intersecting_fold_blocks(grid_blocks, centroids)
@@ -229,7 +245,8 @@ generate_folds_from_blocks <- function(data, centroids, grid_blocks, v, n, radiu
   tibble::tibble(
     splits = split_objs,
     id = names0(length(split_objs), "Fold"),
-    v = v
+    v = v,
+    filtered_number_of_blocks = filtered_number_of_blocks
   )
 }
 

--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -133,8 +133,8 @@ spatial_block_cv <- function(data,
     percent_used <- round(percent_used * 100, 2)
     rlang::inform(
       c(
-        glue::glue("Only {percent_used}% of blocks contained any data"),
-        i = "Check to make sure your block sizes make sense for your data"
+        glue::glue("Only {percent_used}% of blocks contain any data"),
+        i = "Check that your block sizes make sense for your data"
       )
     )
   }

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -119,6 +119,29 @@
       10 <split [2870/60]>  Fold10
       # ... with 44 more rows
 
+---
+
+    Code
+      spatial_block_cv(boston_canopy, n = 200)
+    Message
+      Only 1.7% of blocks contained any data
+      i Check to make sure your block sizes make sense for your data
+    Output
+      #  10-fold spatial block cross-validation 
+      # A tibble: 10 x 2
+         splits           id    
+         <list>           <chr> 
+       1 <split [613/69]> Fold01
+       2 <split [613/69]> Fold02
+       3 <split [614/68]> Fold03
+       4 <split [614/68]> Fold04
+       5 <split [614/68]> Fold05
+       6 <split [614/68]> Fold06
+       7 <split [614/68]> Fold07
+       8 <split [614/68]> Fold08
+       9 <split [614/68]> Fold09
+      10 <split [614/68]> Fold10
+
 # printing
 
     #  10-fold spatial block cross-validation 

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -124,8 +124,8 @@
     Code
       spatial_block_cv(boston_canopy, n = 200)
     Message
-      Only 1.7% of blocks contained any data
-      i Check to make sure your block sizes make sense for your data
+      Only 1.7% of blocks contain any data
+      i Check that your block sizes make sense for your data
     Output
       #  10-fold spatial block cross-validation 
       # A tibble: 10 x 2

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -234,6 +234,12 @@ test_that("bad args", {
   expect_snapshot(
     spatial_block_cv(ames_sf, v = 60)
   )
+
+  set.seed(123)
+  expect_snapshot(
+    spatial_block_cv(boston_canopy, n = 200)
+  )
+
 })
 
 test_that("printing", {


### PR DESCRIPTION
This PR fixes #67 by `rlang::inform()`ing the user if fewer than 10% of blocks contain any data. 10% is a completely arbitrary value and I'd be open to other values.