### PR TITLE
Remove dead code

### DIFF
--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -75,8 +75,6 @@ spatial_buffer_vfold_cv <- function(data,
 
     )
   }
-  if (missing(radius)) radius <- NULL
-  if (missing(buffer)) buffer <- NULL
 
   n <- nrow(data)
   v <- check_v(v, n, "rows")


### PR DESCRIPTION
These two lines come immediately after we throw an error for _either_ of these being `missing`. As such, these should never be called and we can snip them out.