### PR TITLE
Shorten examples

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -29,7 +29,7 @@
 #'
 #' boston_block <- spatial_block_cv(boston_canopy, v = 2)
 #' autoplot(boston_block)
-#' lapply(boston_block$splits, autoplot)
+#' autoplot(boston_block$splits[[1]])
 #'
 #' @rdname autoplot.spatial_rset
 # registered in zzz.R

--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -41,11 +41,20 @@
 #' @rdname spatial_vfold
 #'
 #' @examplesIf sf::sf_use_s2() && rlang::is_installed("modeldata")
-#' boston_vfold <- spatial_buffer_vfold_cv(
-#'   boston_canopy,
+#'
+#' data(Smithsonian, package = "modeldata")
+#' Smithsonian_sf <- sf::st_as_sf(
+#'   Smithsonian,
+#'   coords = c("longitude", "latitude"),
+#'   crs = 4326
+#' )
+#'
+#' spatial_buffer_vfold_cv(
+#'   Smithsonian_sf,
 #'   buffer = 500,
 #'   radius = NULL
 #' )
+#'
 #' data(ames, package = "modeldata")
 #' ames_sf <- sf::st_as_sf(ames, coords = c("Longitude", "Latitude"), crs = 4326)
 #' ames_neighborhoods <- spatial_leave_location_out_cv(ames_sf, Neighborhood)

--- a/man/autoplot.spatial_rset.Rd
+++ b/man/autoplot.spatial_rset.Rd
@@ -46,6 +46,6 @@ Alternatively, consider plotting each split using the \code{spatial_rsplit} meth
 
 boston_block <- spatial_block_cv(boston_canopy, v = 2)
 autoplot(boston_block)
-lapply(boston_block$splits, autoplot)
+autoplot(boston_block$splits[[1]])
 
 }

--- a/man/spatial_vfold.Rd
+++ b/man/spatial_vfold.Rd
@@ -80,11 +80,20 @@ is equivalent to \code{\link[rsample:group_vfold_cv]{rsample::group_vfold_cv()}}
 }
 \examples{
 \dontshow{if (sf::sf_use_s2() && rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-boston_vfold <- spatial_buffer_vfold_cv(
-  boston_canopy,
+
+data(Smithsonian, package = "modeldata")
+Smithsonian_sf <- sf::st_as_sf(
+  Smithsonian,
+  coords = c("longitude", "latitude"),
+  crs = 4326
+)
+
+spatial_buffer_vfold_cv(
+  Smithsonian_sf,
   buffer = 500,
   radius = NULL
 )
+
 data(ames, package = "modeldata")
 ames_sf <- sf::st_as_sf(ames, coords = c("Longitude", "Latitude"), crs = 4326)
 ames_neighborhoods <- spatial_leave_location_out_cv(ames_sf, Neighborhood)


### PR DESCRIPTION
This fixes #86 . 

I _believe_ based on [this CI run](https://github.com/tidymodels/spatialsample/runs/6936300834?check_suite_focus=true#step:7:103) that `spatial_buffer_vfold_cv` is the problematic example, but I shortened the autoplot example as well.

Old examples are x1, new ones x2:
``` r
library(spatialsample)
x1 <- function() {
  spatial_buffer_vfold_cv(
    boston_canopy,
    buffer = 500,
    radius = NULL
  )
  return(TRUE)
}

x2 <- function() {
  data(Smithsonian, package = "modeldata")
  Smithsonian_sf <- sf::st_as_sf(
    Smithsonian,
    coords = c("longitude", "latitude"),
    crs = 4326
  )
  spatial_buffer_vfold_cv(
    Smithsonian_sf,
    buffer = 500,
    radius = NULL
  )
  return(TRUE)
}

bench::mark(
  x1(),
  x2()
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x1()          3.72s    3.72s     0.269    36.8MB    0.269
#> 2 x2()        11.35ms  11.54ms    82.3         3MB    9.80

x1 <- function() {
  set.seed(123)
  boston_block <- spatial_block_cv(boston_canopy, v = 2)
  print(lapply(boston_block$splits, autoplot))
  return(TRUE)
}

x2 <- function() {
  set.seed(123)
  boston_block <- spatial_block_cv(boston_canopy, v = 2)
  print(autoplot(boston_block$splits[[1]]))
  return(TRUE)
}

bench::mark(
  x1(),
  x2()
)
#> [[1]]

    #> # A tibble: 2 × 6
    #>   expression      min   median `itr/sec` mem_alloc `gc/sec`
    #>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
    #> 1 x1()          468ms    487ms      2.06    42.5MB     8.22
    #> 2 x2()          269ms    321ms      3.12    18.5MB     6.24
```
<sup>Created on 2022-06-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>