### PR TITLE
Clean up spatial_clustering_cv() docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Config/testthat/parallel: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 LinkingTo: 
     cpp11
 SystemRequirements: C++11

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -1,19 +1,16 @@
-#' Spatial or Cluster Cross-Validation
+#' Spatial Clustering Cross-Validation
 #'
-#' Spatial or cluster cross-validation splits the data into V groups of
-#'  disjointed sets using k-means clustering of some variables, typically
-#'  spatial coordinates. A resample of the analysis data consists of V-1 of the
-#'  folds/clusters while the assessment set contains the final fold/cluster. In
-#'  basic spatial cross-validation (i.e. no repeats), the number of resamples
-#'  is equal to V.
+#' Spatial clustering cross-validation splits the data into V groups of
+#'  disjointed sets by clustering points based on their spatial coordinates.
+#'  A resample of the analysis data consists of V-1 of the folds/clusters
+#'  while the assessment set contains the final fold/cluster.
 #'
 #' @details
-#' The variables in the `coords` argument are used for k-means clustering of
-#'  the data into disjointed sets, as outlined in Brenning (2012), or for
-#'  hierarchical clustering of the data. These
-#'  clusters are used as the folds for cross-validation. Depending on how the
-#'  data are distributed spatially, there may not be an equal number of points
-#'  in each fold.
+#' Clusters are created based on either the distances between observations
+#'  (if `data` is an `sf` object) or by clustering the variables in the `coords`
+#'  argument. Each cluster is used as a fold for cross-validation.
+#'  Depending on how the data are distributed spatially, there may not be an
+#'  equal number of observations in each fold.
 #'
 #' You can optionally provide a custom function to `cluster_function`. The
 #' function must take three arguments:
@@ -28,7 +25,7 @@
 #' @param data A data frame or an `sf` object (often from [sf::read_sf()]
 #' or [sf::st_as_sf()]), to split into folds.
 #' @param coords A vector of variable names, typically spatial coordinates,
-#'  to partition the data into disjointed sets via k-means clustering.
+#'  to partition the data into disjointed sets via clustering.
 #'  This argument is ignored (with a warning) if `data` is an `sf` object.
 #' @inheritParams buffer_indices
 #' @param v The number of partitions of the data set.

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/spatial_clustering_cv.R
 \name{spatial_clustering_cv}
 \alias{spatial_clustering_cv}
-\title{Spatial or Cluster Cross-Validation}
+\title{Spatial Clustering Cross-Validation}
 \usage{
 spatial_clustering_cv(
   data,
@@ -19,7 +19,7 @@ spatial_clustering_cv(
 or \code{\link[sf:st_as_sf]{sf::st_as_sf()}}), to split into folds.}
 
 \item{coords}{A vector of variable names, typically spatial coordinates,
-to partition the data into disjointed sets via k-means clustering.
+to partition the data into disjointed sets via clustering.
 This argument is ignored (with a warning) if \code{data} is an \code{sf} object.}
 
 \item{v}{The number of partitions of the data set.}
@@ -49,20 +49,17 @@ Resamples created from non-\code{sf} objects will not have the
 \code{spatial_rset} class.
 }
 \description{
-Spatial or cluster cross-validation splits the data into V groups of
-disjointed sets using k-means clustering of some variables, typically
-spatial coordinates. A resample of the analysis data consists of V-1 of the
-folds/clusters while the assessment set contains the final fold/cluster. In
-basic spatial cross-validation (i.e. no repeats), the number of resamples
-is equal to V.
+Spatial clustering cross-validation splits the data into V groups of
+disjointed sets by clustering points based on their spatial coordinates.
+A resample of the analysis data consists of V-1 of the folds/clusters
+while the assessment set contains the final fold/cluster.
 }
 \details{
-The variables in the \code{coords} argument are used for k-means clustering of
-the data into disjointed sets, as outlined in Brenning (2012), or for
-hierarchical clustering of the data. These
-clusters are used as the folds for cross-validation. Depending on how the
-data are distributed spatially, there may not be an equal number of points
-in each fold.
+Clusters are created based on either the distances between observations
+(if \code{data} is an \code{sf} object) or by clustering the variables in the \code{coords}
+argument. Each cluster is used as a fold for cross-validation.
+Depending on how the data are distributed spatially, there may not be an
+equal number of observations in each fold.
 
 You can optionally provide a custom function to \code{cluster_function}. The
 function must take three arguments:


### PR DESCRIPTION
This PR trims down the `spatial_clustering_cv()` documentation to more closely align with the current state of the function. 

I think in the future a lot of this documentation will be inherited from `clustering_cv()` in `rsample`; because of that, I tried to only touch the spatialsample-specific pieces. Similarly, I didn't rewrite any of the code to match improvements from `clustering_cv()`, because probably in the near future this function will be moved to wrap that function directly.

Fixes #103