### PR TITLE
Test new rsample helper functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     glue,
     purrr,
     rlang (>= 1.0.0),
-    rsample (>= 0.0.9),
+    rsample (>= 1.1.0),
     sf,
     tibble,
     tidyselect,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # spatialsample (development version)
 
+* Outputs from `spatial_buffer_vfold_cv()` should now have the correct `radius` and `buffer` attributes (#110).
+
 # spatialsample 0.2.1
 
 * Mike Mahoney is taking over as package maintainer, as Julia Silge (who remains

--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -113,8 +113,8 @@ spatial_buffer_vfold_cv <- function(data,
                  pool    = pool,
                  # Set radius and buffer to 0 if NULL or negative
                  # This enables rsample::reshuffle_rset to work
-                 radius  = min(c(radius, 0)),
-                 buffer  = min(c(buffer, 0)))
+                 radius  = max(c(radius, 0)),
+                 buffer  = max(c(buffer, 0)))
 
   if ("sf" %in% class(data)) {
     rset_class <- c("spatial_buffer_vfold_cv", "spatial_rset", "rset")

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -57,3 +57,42 @@ test_that("check_v handles NULL and Inf appropriately", {
   )
 
 })
+
+test_that("reverse_splits is working", {
+  skip_if_not(rlang::is_installed("withr"))
+
+  for (x in rset_subclasses) {
+
+    set.seed(123)
+    rev_x <- rsample::reverse_splits(x)
+    expect_identical(analysis(x$splits[[1]]), assessment(rev_x$splits[[1]]))
+    expect_identical(assessment(x$splits[[1]]), analysis(rev_x$splits[[1]]))
+    expect_identical(class(x), class(rev_x))
+    expect_identical(class(x$splits[[1]]), class(rev_x$splits[[1]]))
+
+  }
+
+})
+
+test_that("reshuffle_rset is working", {
+
+  skip_if_not(rlang::is_installed("withr"))
+
+  # Reshuffling with the same seed, in the same order,
+  # should recreate the same objects
+  out <- withr::with_seed(
+    123,
+    lapply(
+      rset_subclasses,
+      function(x) suppressWarnings(rsample::reshuffle_rset(x))
+    )
+  )
+
+  for (i in seq_along(rset_subclasses)) {
+    expect_identical(
+      out[[i]],
+      rset_subclasses[[i]]
+    )
+  }
+
+})


### PR DESCRIPTION
This PR fixes #98 by testing `reverse_splits()` and `reshuffle_rset()` on all functions in `rset_subclasses`. It also fixes a bug -- I was setting the `radius` and `buffer` attributes to `min(<argument>, 0)` in order to set these to 0 if they're 0, `NULL`, or negative, so that `reshuffle_rset()` works, when that should have always been `max`.