### PR TITLE
Add repeat argument to spatial_block_cv()

### DIFF
--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -157,6 +157,7 @@ spatial_block_cv <- function(data,
                  relevant_only = relevant_only,
                  radius = radius,
                  buffer = buffer,
+                 repeats = repeats,
                  ...)
 
   new_rset(

--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -60,8 +60,21 @@ spatial_block_cv <- function(data,
                              relevant_only = TRUE,
                              radius = NULL,
                              buffer = NULL,
-                             ...) {
+                             ...,
+                             repeats = 1) {
   method <- rlang::arg_match(method)
+
+  if (method != "random" && repeats != 1) {
+    rlang::abort(
+      c(
+        glue::glue(
+          "Repeated cross-validation doesn't make sense when `method = '{method}'`."
+        ),
+        i = "Set `method = 'random'`.",
+        i = "Or set `repeats = 1`."
+      )
+    )
+  }
 
   standard_checks(data, "`spatial_block_cv()`")
 
@@ -80,27 +93,45 @@ spatial_block_cv <- function(data,
 
   grid_blocks <- sf::st_make_grid(grid_box, ...)
   original_number_of_blocks <- length(grid_blocks)
-  split_objs <- switch(
-    method,
-    "random" = random_block_cv(
-      data,
-      centroids,
-      grid_blocks,
-      v,
-      radius = radius,
-      buffer = buffer
-    ),
-    systematic_block_cv(
-      data,
-      centroids,
-      grid_blocks,
-      v,
-      ordering = method,
-      relevant_only,
-      radius = radius,
-      buffer = buffer
+
+  block_fun <- function(method) {
+    switch(
+      method,
+      "random" = random_block_cv(
+        data,
+        centroids,
+        grid_blocks,
+        v,
+        radius = radius,
+        buffer = buffer
+      ),
+      systematic_block_cv(
+        data,
+        centroids,
+        grid_blocks,
+        v,
+        ordering = method,
+        relevant_only,
+        radius = radius,
+        buffer = buffer
+      )
     )
-  )
+  }
+
+  if (repeats == 1) {
+    split_objs <- block_fun(method)
+  } else {
+    for (i in 1:repeats) {
+      tmp <- block_fun(method)
+      tmp$id2 <- tmp$id
+      tmp$id <- names0(repeats, "Repeat")[i]
+      split_objs <- if (i == 1) {
+        tmp
+      } else {
+        rbind(split_objs, tmp)
+      }
+    }
+  }
 
   percent_used <- split_objs$filtered_number_of_blocks[[1]] / original_number_of_blocks
 
@@ -155,7 +186,7 @@ random_block_cv <- function(data,
   grid_blocks <- filter_grid_blocks(grid_blocks, centroids)
 
   n_blocks <- length(grid_blocks)
-  v <- check_v(v, n_blocks, "blocks", call = rlang::caller_env())
+  v <- check_v(v, n_blocks, "blocks", call = rlang::caller_env(2))
 
   grid_blocks <- sf::st_as_sf(grid_blocks)
   grid_blocks$fold <- sample(rep(seq_len(v), length.out = nrow(grid_blocks)))
@@ -177,7 +208,7 @@ systematic_block_cv <- function(data,
   if (relevant_only) grid_blocks <- filter_grid_blocks(grid_blocks, centroids)
 
   n_blocks <- length(grid_blocks)
-  v <- check_v(v, n_blocks, "blocks", call = rlang::caller_env())
+  v <- check_v(v, n_blocks, "blocks", call = rlang::caller_env(2))
 
   folds <- rep(seq_len(v), length.out = length(grid_blocks))
   if (ordering == "snake") folds <- make_snake_ordering(folds, grid_blocks)

--- a/man/spatial_block_cv.Rd
+++ b/man/spatial_block_cv.Rd
@@ -11,7 +11,8 @@ spatial_block_cv(
   relevant_only = TRUE,
   radius = NULL,
   buffer = NULL,
-  ...
+  ...,
+  repeats = 1
 )
 }
 \arguments{
@@ -39,6 +40,8 @@ test set (after \code{radius} is applied) will be assigned to neither the analys
 or assessment set. If \code{NULL}, no buffer is applied.}
 
 \item{...}{Arguments passed to \code{\link[sf:st_make_grid]{sf::st_make_grid()}}.}
+
+\item{repeats}{The number of times to repeat the V-fold partitioning.}
 }
 \value{
 A tibble with classes \code{spatial_block_cv},  \code{spatial_rset}, \code{rset},

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -221,6 +221,18 @@
        9 <split [614/68]> Fold09
       10 <split [614/68]> Fold10
 
+---
+
+    Repeated cross-validation doesn't make sense when `method = 'continuous'`.
+    i Set `method = 'random'`.
+    i Or set `repeats = 1`.
+
+---
+
+    Repeated cross-validation doesn't make sense when `method = 'snake'`.
+    i Set `method = 'random'`.
+    i Or set `repeats = 1`.
+
 # printing
 
     #  10-fold spatial block cross-validation 

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -45,6 +45,25 @@ test_that("random assignment", {
   expect_true(all(good_holdout))
 })
 
+test_that("repeated", {
+  set.seed(11)
+  rs2 <- spatial_block_cv(ames_sf, repeats = 2)
+
+  same_data <-
+    purrr::map_lgl(rs2$splits, function(x) {
+      all.equal(x$data, ames_sf)
+    })
+  expect_true(all(same_data))
+
+  good_holdout <- purrr::map_lgl(
+    rs2$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+})
+
 test_that("systematic assignment -- snake", {
   skip_if_not(sf::sf_use_s2())
   set.seed(11)
@@ -249,6 +268,16 @@ test_that("bad args", {
   set.seed(123)
   expect_snapshot(
     spatial_block_cv(boston_canopy, n = 200)
+  )
+
+  set.seed(123)
+  expect_snapshot_error(
+    spatial_block_cv(boston_canopy, method = "continuous", repeats = 2)
+  )
+
+  set.seed(123)
+  expect_snapshot_error(
+    spatial_block_cv(boston_canopy, method = "snake", repeats = 2)
   )
 
 })


### PR DESCRIPTION
This PR fixes #117 by adding a `repeats` argument to `spatial_block_cv()`. 

I've added the argument after `...`, because I _want_ to add it after `v` for consistency, but don't know if this merits a breaking change. The argument goes after `v` in [rsample](https://rsample.tidymodels.org/reference/vfold_cv.html) and [`spatial_buffer_vfold_cv()`](https://spatialsample.tidymodels.org/reference/spatial_vfold.html), but doing so here would be breaking for the other four functions in spatialsample.

``` r
library(spatialsample)

spatial_block_cv(
  boston_canopy,
  v = 2,
  repeats = 2
)
#> #  2-fold spatial block cross-validation 
#> # A tibble: 4 × 3
#>   splits            id      id2  
#>   <list>            <chr>   <chr>
#> 1 <split [363/319]> Repeat1 Fold1
#> 2 <split [319/363]> Repeat1 Fold2
#> 3 <split [340/342]> Repeat2 Fold1
#> 4 <split [342/340]> Repeat2 Fold2
```

<sup>Created on 2022-11-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>