### PR TITLE
Add repeats to spatial_leave_location_out_cv()

### DIFF
--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -156,7 +156,8 @@ spatial_leave_location_out_cv <- function(data,
                                           v = NULL,
                                           radius = NULL,
                                           buffer = NULL,
-                                          ...) {
+                                          ...,
+                                          repeats = 1) {
 
   if (!missing(group)) {
     group <- tidyselect::eval_select(rlang::enquo(group), data)
@@ -167,14 +168,23 @@ spatial_leave_location_out_cv <- function(data,
   } else {
     if (is.null(v)) v <- length(unique(data[[group]]))
     v <- check_v(v, length(unique(data[[group]])), "locations")
+    n <- nrow(data)
+    if (v == n && repeats > 1) {
+      rlang::abort(
+        c(
+          "Repeated cross-validation doesn't make sense when performing leave-one-location-out cross-validation.",
+          i = "Set `v` to a lower value.",
+          i = "Or set `repeats = 1`."
+        )
+      )
+    }
   }
-
-  n <- nrow(data)
 
   rset <- rsample::group_vfold_cv(
     data = data,
     v = v,
     group = {{ group }},
+    repeats = {{ repeats }},
     ...
   )
 

--- a/man/spatial_vfold.Rd
+++ b/man/spatial_vfold.Rd
@@ -23,7 +23,8 @@ spatial_leave_location_out_cv(
   v = NULL,
   radius = NULL,
   buffer = NULL,
-  ...
+  ...,
+  repeats = 1
 )
 }
 \arguments{

--- a/tests/testthat/_snaps/spatial_vfold_cv.md
+++ b/tests/testthat/_snaps/spatial_vfold_cv.md
@@ -32,6 +32,20 @@
       3 <split [1465/1465]> Repeat2 Fold1
       4 <split [1465/1465]> Repeat2 Fold2
 
+# spatial_leave_location_out_cv
+
+    Code
+      rs1
+    Output
+      #  2-fold spatial leave-location-out cross-validation 
+      # A tibble: 4 x 3
+        splits              id      id2      
+        <list>              <chr>   <chr>    
+      1 <split [1268/1662]> Repeat1 Resample1
+      2 <split [1662/1268]> Repeat1 Resample2
+      3 <split [1548/1382]> Repeat2 Resample1
+      4 <split [1382/1548]> Repeat2 Resample2
+
 # bad args
 
     Code
@@ -148,6 +162,10 @@
     Repeated cross-validation doesn't make sense when performing leave-one-out cross-validation.
     i Set `v` to a lower value.
     i Or set `repeats = 1`.
+
+---
+
+    Repeated resampling when `v` is 28 would create identical resamples
 
 # printing
 

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -64,6 +64,21 @@ test_that("spatial_buffer_vfold_cv", {
     c("splits", "id", "id2")
   )
   expect_snapshot(rs1)
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
+      isTRUE(all.equal(x$data, ames_sf))
+    }
+  )
+  expect_true(all(same_data))
+
+  good_holdout <- map_lgl(
+    rs1$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
 
 
 })
@@ -83,6 +98,34 @@ test_that("spatial_leave_location_out_cv", {
   )
 
   expect_true(all(sizes1$analysis + sizes1$assessment == nrow(ames)))
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
+      isTRUE(all.equal(x$data, ames_sf))
+    }
+  )
+  expect_true(all(same_data))
+
+  good_holdout <- map_lgl(
+    rs1$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+
+  set.seed(123)
+  rs1 <- spatial_leave_location_out_cv(
+    ames_sf,
+    Neighborhood,
+    v = 2,
+    repeats = 2
+  )
+  expect_identical(
+    names(rs1),
+    c("splits", "id", "id2")
+  )
+  expect_snapshot(rs1)
   same_data <- map_lgl(
     rs1$splits,
     function(x) {
@@ -164,6 +207,15 @@ test_that("bad args", {
       v = 682,
       buffer = NULL,
       radius = NULL,
+      repeats = 2
+    )
+  )
+
+  set.seed(123)
+  expect_snapshot_error(
+    spatial_leave_location_out_cv(
+      ames_sf,
+      Neighborhood,
       repeats = 2
     )
   )

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -121,11 +121,6 @@ test_that("spatial_leave_location_out_cv", {
     v = 2,
     repeats = 2
   )
-  expect_identical(
-    names(rs1),
-    c("splits", "id", "id2")
-  )
-  expect_snapshot(rs1)
   same_data <- map_lgl(
     rs1$splits,
     function(x) {
@@ -141,6 +136,13 @@ test_that("spatial_leave_location_out_cv", {
     }
   )
   expect_true(all(good_holdout))
+
+  expect_identical(
+    names(rs1),
+    c("splits", "id", "id2")
+  )
+  skip_if_not(getRversion() >= numeric_version("3.6.0"))
+  expect_snapshot(rs1)
 
 })
 


### PR DESCRIPTION
Fixes #118

``` r
library(spatialsample)
data(ames, package = "modeldata")
ames_sf <- sf::st_as_sf(ames, coords = c("Longitude", "Latitude"), crs = 4326)
spatial_leave_location_out_cv(
  ames_sf,
  Neighborhood,
  v = 2,
  repeats = 2
)
#> #  2-fold spatial leave-location-out cross-validation 
#> # A tibble: 4 × 2
#>   splits              id   
#>   <list>              <chr>
#> 1 <split [1036/1894]> Fold1
#> 2 <split [1894/1036]> Fold2
#> 3 <split [1052/1878]> Fold3
#> 4 <split [1878/1052]> Fold4
```

<sup>Created on 2022-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>