### PR TITLE
Wrap clustering_cv()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     glue,
     purrr,
     rlang (>= 1.0.0),
-    rsample (>= 1.1.0),
+    rsample (>= 1.1.1),
     sf (>= 1.0-9),
     tibble,
     tidyselect,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Config/testthat/parallel: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 LinkingTo: 
     cpp11
 SystemRequirements: C++11

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,15 @@
 
 * `autoplot()` now handles repeated cross-validation properly.
 
+* `spatial_clustering_cv()` no longer accepts non-sf objects. Use 
+  `rsample::clustering_cv()` for these instead.
+  
+* `spatial_clustering_cv()` now uses edge-to-edge distances, like the rest of
+  the package, rather than centroids.
+  
+* `spatial_clustering_cv()` now has a `distance_function` argument, set by 
+  default to `as.dist(sf::st_distance(x))`. 
+
 # spatialsample 0.2.1
 
 * Mike Mahoney is taking over as package maintainer, as Julia Silge (who remains

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -15,6 +15,16 @@ buffer_indices <- function(data, indices, radius, buffer, call = rlang::caller_e
   standard_checks(data, "Buffering", call)
 
   n <- nrow(data)
+  # calling st_distance is a _huge_ performance hit, especially for big data,
+  # so we make a point of only doing it once.
+  #
+  # This winds up requiring all sorts of weird handler code,
+  # namely `row_ids_within_dist` and `which_within_dist`, in order to
+  # only calculate this matrix
+  #
+  # Using st_is_within_dist is not faster. Using st_intersects is not faster.
+  # I keep trying both of these, and have left this comment in vain hope it
+  # convinces me to stop.
   distmat <- sf::st_distance(data)
 
   # only run radius checks if radius is not NULL (to prevent NAs from >)

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -38,6 +38,10 @@
 #' or [sf::st_as_sf()]), to split into folds.
 #' @inheritParams buffer_indices
 #' @inheritParams rsample::clustering_cv
+#' @param distance_function Which function should be used for distance
+#' calculations? Defaults to [sf::st_distance()], with the output matrix
+#' converted to a [stats::dist()] object. You can also provide your own
+#' function; see Details.
 #' @param v The number of partitions of the data set.
 #' @param cluster_function Which function should be used for clustering?
 #' Options are either `"kmeans"` (to use [stats::kmeans()])

--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -5,12 +5,24 @@
 #'  A resample of the analysis data consists of V-1 of the folds/clusters
 #'  while the assessment set contains the final fold/cluster.
 #'
+#' @section Changes in spatialsample 0.3.0:
+#' As of spatialsample version 0.3.0, this function no longer accepts non-`sf`
+#' objects as arguments to `data`. In order to perform clustering with
+#' non-spatial data, consider using [rsample::clustering_cv()].
+#'
+#' Also as of version 0.3.0, this function now calculates edge-to-edge distance
+#' for non-point geometries, in line with the rest of the package. Earlier
+#' versions relied upon between-centroid distances.
+#'
 #' @details
-#' Clusters are created based on either the distances between observations
-#'  (if `data` is an `sf` object) or by clustering the variables in the `coords`
-#'  argument. Each cluster is used as a fold for cross-validation.
-#'  Depending on how the data are distributed spatially, there may not be an
-#'  equal number of observations in each fold.
+#' Clusters are created based on the distances between observations
+#'  if `data` is an `sf` object. Each cluster is used as a fold for
+#'  cross-validation. Depending on how the data are distributed spatially, there
+#'  may not be an equal number of observations in each fold.
+#'
+#' You can optionally provide a custom function to `distance_function.` The
+#' function should take an `sf` object and return a [stats::dist()] object with
+#' distances between data points.
 #'
 #' You can optionally provide a custom function to `cluster_function`. The
 #' function must take three arguments:
@@ -24,10 +36,8 @@
 #'
 #' @param data A data frame or an `sf` object (often from [sf::read_sf()]
 #' or [sf::st_as_sf()]), to split into folds.
-#' @param coords A vector of variable names, typically spatial coordinates,
-#'  to partition the data into disjointed sets via clustering.
-#'  This argument is ignored (with a warning) if `data` is an `sf` object.
 #' @inheritParams buffer_indices
+#' @inheritParams rsample::clustering_cv
 #' @param v The number of partitions of the data set.
 #' @param cluster_function Which function should be used for clustering?
 #' Options are either `"kmeans"` (to use [stats::kmeans()])
@@ -52,7 +62,6 @@
 #'
 #' @examplesIf rlang::is_installed("modeldata")
 #' data(Smithsonian, package = "modeldata")
-#' spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 5)
 #'
 #' smithsonian_sf <- sf::st_as_sf(
 #'   Smithsonian,
@@ -70,124 +79,56 @@
 #' @rdname spatial_clustering_cv
 #' @export
 spatial_clustering_cv <- function(data,
-                                  coords,
                                   v = 10,
                                   cluster_function = c("kmeans", "hclust"),
                                   radius = NULL,
                                   buffer = NULL,
-                                  ...) {
+                                  ...,
+                                  repeats = 1,
+                                  distance_function = function(x) as.dist(sf::st_distance(x))) {
   if (!rlang::is_function(cluster_function)) {
     cluster_function <- rlang::arg_match(cluster_function)
   }
 
-  subclasses <- c("spatial_clustering_cv", "spatial_rset", "rset")
-  if ("sf" %in% class(data)) {
-    if (!missing(coords)) {
-      rlang::warn("`coords` is ignored when providing `sf` objects to `data`.")
-    }
-    coords <- sf::st_centroid(sf::st_geometry(data))
-    dists <- as.dist(sf::st_distance(coords))
-  } else {
-    if (!missing(radius) || !missing(buffer)) {
-      rlang::abort("Neither `radius` or `buffer` can be used when providing non-`sf` objects to `data`.")
-    }
-    coords <- tidyselect::eval_select(rlang::enquo(coords), data = data)
-    if (is_empty(coords)) {
-      rlang::abort("`coords` are required and must be variables in `data`.")
-    }
-    coords <- data[coords]
-    if (!all(purrr::map_lgl(coords, is.numeric))) {
-      rlang::abort("`coords` must be numeric variables in `data`.")
-    }
-    dists <- dist(coords)
-    subclasses <- setdiff(subclasses, "spatial_rset")
-  }
+  standard_checks(data, "`spatial_clustering_cv()`")
 
-  split_objs <- spatial_clustering_splits(
-    data = data,
-    dists = dists,
+  n <- nrow(data)
+  v <- check_v(
+    v,
+    n,
+    "data points",
+    allow_max_v = FALSE
+  )
+
+  cv_att <- list(
     v = v,
-    cluster_function = cluster_function,
+    repeats = repeats,
     radius = radius,
     buffer = buffer,
+    cluster_function = cluster_function,
+    distance_function = distance_function
+  )
+
+  rset <- rsample::clustering_cv(
+    data = data,
+    vars = names(data),
+    v = v,
+    repeats = {{ repeats }},
+    distance_function = distance_function,
+    cluster_function = cluster_function,
     ...
   )
 
-  split_objs$splits <- map(split_objs$splits, rm_out, buffer = buffer)
-
-  ## Save some overall information
-
-  cv_att <- list(v = v, repeats = 1, radius = radius, buffer = buffer)
-
-  new_rset(
-    splits = split_objs$splits,
-    ids = split_objs[, grepl("^id", names(split_objs))],
-    attrib = cv_att,
-    subclass = subclasses
-  )
-}
-
-spatial_clustering_splits <- function(data,
-                                      dists,
-                                      v = 10,
-                                      cluster_function = c("kmeans", "hclust"),
-                                      radius = NULL,
-                                      buffer = NULL,
-                                      ...) {
-  if (!rlang::is_function(cluster_function)) {
-    cluster_function <- rlang::arg_match(cluster_function)
-  }
-
-  v <- check_v(v, nrow(data), "data points", allow_max_v = FALSE, call = rlang::caller_env())
-
-  classes <- c("spatial_clustering_split")
-  if ("sf" %in% class(data)) classes <- c(classes, "spatial_rsplit")
-
-  classes <- c("spatial_clustering_split")
-  if ("sf" %in% class(data)) classes <- c(classes, "spatial_rsplit")
-
-  n <- nrow(data)
-
-  clusterer <- ifelse(
-    rlang::is_function(cluster_function),
-    "custom",
-    cluster_function
-  )
-
-  folds <- switch(
-    clusterer,
-    "kmeans" = {
-      clusters <- kmeans(dists, centers = v, ...)
-      clusters$cluster
-    },
-    "hclust" = {
-      clusters <- hclust(dists, ...)
-      cutree(clusters, k = v)
-    },
-    do.call(cluster_function, list(dists = dists, v = v, ...))
-  )
-
-  idx <- seq_len(n)
-  indices <- split_unnamed(idx, folds)
-  if (is.null(radius) && is.null(buffer)) {
-    indices <- lapply(indices, default_complement, n = n)
-  } else {
-    indices <- buffer_indices(
-      data,
-      indices,
-      radius,
-      buffer,
-      call = rlang::caller_env()
-    )
-  }
-  split_objs <- purrr::map(
-    indices,
-    make_splits,
+  posthoc_buffer_rset(
     data = data,
-    class = classes
-  )
-  tibble::tibble(
-    splits = split_objs,
-    id = names0(length(split_objs), "Fold")
+    rset = rset,
+    rsplit_class = c("spatial_clustering_split", "spatial_rsplit"),
+    rset_class = c("spatial_clustering_cv", "spatial_rset", "rset"),
+    radius = radius,
+    buffer = buffer,
+    n = n,
+    v = v,
+    cv_att = cv_att
   )
 }
+

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -6,21 +6,18 @@
 \usage{
 spatial_clustering_cv(
   data,
-  coords,
   v = 10,
   cluster_function = c("kmeans", "hclust"),
   radius = NULL,
   buffer = NULL,
-  ...
+  ...,
+  repeats = 1,
+  distance_function = function(x) as.dist(sf::st_distance(x))
 )
 }
 \arguments{
 \item{data}{A data frame or an \code{sf} object (often from \code{\link[sf:st_read]{sf::read_sf()}}
 or \code{\link[sf:st_as_sf]{sf::st_as_sf()}}), to split into folds.}
-
-\item{coords}{A vector of variable names, typically spatial coordinates,
-to partition the data into disjointed sets via clustering.
-This argument is ignored (with a warning) if \code{data} is an \code{sf} object.}
 
 \item{v}{The number of partitions of the data set.}
 
@@ -39,6 +36,12 @@ or assessment set. If \code{NULL}, no buffer is applied.}
 
 \item{...}{Extra arguments passed on to \code{\link[stats:kmeans]{stats::kmeans()}} or
 \code{\link[stats:hclust]{stats::hclust()}}.}
+
+\item{repeats}{The number of times to repeat the clustered partitioning.}
+
+\item{distance_function}{Which function should be used for distance calculations?
+Defaults to \code{\link[stats:dist]{stats::dist()}}. You can also provide your own
+function; see \code{Details}.}
 }
 \value{
 A tibble with classes \code{spatial_clustering_cv}, \code{spatial_rset},
@@ -55,11 +58,14 @@ A resample of the analysis data consists of V-1 of the folds/clusters
 while the assessment set contains the final fold/cluster.
 }
 \details{
-Clusters are created based on either the distances between observations
-(if \code{data} is an \code{sf} object) or by clustering the variables in the \code{coords}
-argument. Each cluster is used as a fold for cross-validation.
-Depending on how the data are distributed spatially, there may not be an
-equal number of observations in each fold.
+Clusters are created based on the distances between observations
+if \code{data} is an \code{sf} object. Each cluster is used as a fold for
+cross-validation. Depending on how the data are distributed spatially, there
+may not be an equal number of observations in each fold.
+
+You can optionally provide a custom function to \code{distance_function.} The
+function should take an \code{sf} object and return a \code{\link[stats:dist]{stats::dist()}} object with
+distances between data points.
 
 You can optionally provide a custom function to \code{cluster_function}. The
 function must take three arguments:
@@ -73,10 +79,20 @@ The function should return a vector of cluster assignments of length
 \code{nrow(data)}, with each element of the vector corresponding to the matching
 row of the data frame.
 }
+\section{Changes in spatialsample 0.3.0}{
+
+As of spatialsample version 0.3.0, this function no longer accepts non-\code{sf}
+objects as arguments to \code{data}. In order to perform clustering with
+non-spatial data, consider using \code{\link[rsample:clustering_cv]{rsample::clustering_cv()}}.
+
+Also as of version 0.3.0, this function now calculates edge-to-edge distance
+for non-point geometries, in line with the rest of the package. Earlier
+versions relied upon between-centroid distances.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 data(Smithsonian, package = "modeldata")
-spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 5)
 
 smithsonian_sf <- sf::st_as_sf(
   Smithsonian,

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -39,9 +39,10 @@ or assessment set. If \code{NULL}, no buffer is applied.}
 
 \item{repeats}{The number of times to repeat the clustered partitioning.}
 
-\item{distance_function}{Which function should be used for distance calculations?
-Defaults to \code{\link[stats:dist]{stats::dist()}}. You can also provide your own
-function; see \code{Details}.}
+\item{distance_function}{Which function should be used for distance
+calculations? Defaults to \code{\link[sf:geos_measures]{sf::st_distance()}}, with the output matrix
+converted to a \code{\link[stats:dist]{stats::dist()}} object. You can also provide your own
+function; see Details.}
 }
 \value{
 A tibble with classes \code{spatial_clustering_cv}, \code{spatial_rset},

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -1,5 +1,0 @@
-# autoplot is stable
-
-    Objects of class <spatial_clustering_cv> are not supported by autoplot.
-    i have you loaded the required package?
-

--- a/tests/testthat/_snaps/spatial_clustering_cv.md
+++ b/tests/testthat/_snaps/spatial_clustering_cv.md
@@ -1,7 +1,16 @@
 # bad args
 
     Code
-      spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = "a")
+      spatial_clustering_cv(Smithsonian)
+    Condition
+      Error in `spatial_clustering_cv()`:
+      ! `spatial_clustering_cv()` currently only supports `sf` objects.
+      i Try converting `data` to an `sf` object via `sf::st_as_sf()`.
+
+---
+
+    Code
+      spatial_clustering_cv(Smithsonian_sf, v = "a")
     Condition
       Error in `spatial_clustering_cv()`:
       ! `v` must be a single positive integer.
@@ -9,7 +18,7 @@
 ---
 
     Code
-      spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = c(5, 10))
+      spatial_clustering_cv(Smithsonian_sf, v = c(5, 10))
     Condition
       Error in `spatial_clustering_cv()`:
       ! `v` must be a single positive integer.
@@ -17,27 +26,16 @@
 ---
 
     Code
-      spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 100)
+      spatial_clustering_cv(Smithsonian_sf, v = 100)
     Condition
       Error in `spatial_clustering_cv()`:
       ! The number of data points is less than `v = 100` (20)
       i Set `v` to a smaller value than 20
 
----
-
-    Code
-      spatial_clustering_cv(Smithsonian, name)
-    Condition
-      Error in `spatial_clustering_cv()`:
-      ! `coords` must be numeric variables in `data`.
-
 # using sf
 
     Code
-      spatial_clustering_cv(Smithsonian_sf, coords = c(latitude, longitude))
-    Condition
-      Warning:
-      `coords` is ignored when providing `sf` objects to `data`.
+      spatial_clustering_cv(Smithsonian_sf)
     Output
       #  10-fold spatial cross-validation 
       # A tibble: 10 x 2

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -9,9 +9,6 @@ test_that("autoplot is stable", {
   set.seed(123)
   ames_cluster <- spatial_clustering_cv(ames_sf)
 
-  set.seed(123)
-  ames_non_sf <- spatial_clustering_cv(ames, coords = c("Longitude", "Latitude"))
-
   p <- autoplot(ames_cluster)
   vdiffr::expect_doppelganger("cluster plots", p)
 
@@ -85,9 +82,6 @@ test_that("autoplot is stable", {
   )
   p <- autoplot(boston_snake)
   vdiffr::expect_doppelganger("snake flips rows the right way", p)
-
-
-  expect_snapshot_error(autoplot(ames_non_sf))
 
   set.seed(123)
   repeat_block <- spatial_block_cv(

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -222,6 +222,7 @@ test_that("using buffers", {
   # These should be the only changes between 0 and NULL:
   attr(rs2, "radius") <- NULL
   attr(rs2, "buffer") <- NULL
+  attr(rs2, "distance_function") <- attr(rs1, "distance_function")
   attr(rs2, "fingerprint") <- attr(rs1, "fingerprint")
   rs2$splits <- map(rs2$splits, rm_out)
 

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -10,126 +10,12 @@ Smithsonian_sf <- sf::st_as_sf(
   crs = 4326
 )
 
-test_that("using kmeans", {
-  set.seed(11)
-  rs1 <- spatial_clustering_cv(
-    Smithsonian,
-    coords = c(latitude, longitude),
-    v = 2
-  )
-  set.seed(11)
-  rs2 <- spatial_clustering_cv(
-    Smithsonian,
-    coords = c(latitude, longitude),
-    v = 2,
-    cluster_function = "kmeans"
-  )
-  expect_identical(rs1, rs2)
-  sizes1 <- dim_rset(rs1)
-
-  expect_true(all(sizes1$analysis + sizes1$assessment == 20))
-  same_data <- map_lgl(
-    rs1$splits,
-    function(x) {
-      isTRUE(all.equal(x$data, Smithsonian))
-    }
-  )
-  expect_true(all(same_data))
-
-  good_holdout <- map_lgl(
-    rs1$splits,
-    function(x) {
-      length(intersect(x$in_ind, x$out_id)) == 0
-    }
-  )
-  expect_true(all(good_holdout))
-})
-
-
-test_that("using hclust", {
-  set.seed(11)
-  rs1 <- spatial_clustering_cv(
-    Smithsonian,
-    coords = c(latitude, longitude),
-    v = 2,
-    cluster_function = "hclust"
-  )
-  sizes1 <- dim_rset(rs1)
-
-  expect_true(all(sizes1$analysis + sizes1$assessment == 20))
-  same_data <- map_lgl(
-    rs1$splits,
-    function(x) {
-      isTRUE(all.equal(x$data, Smithsonian))
-    }
-  )
-  expect_true(all(same_data))
-
-  good_holdout <- map_lgl(
-    rs1$splits,
-    function(x) {
-      length(intersect(x$in_ind, x$out_id)) == 0
-    }
-  )
-  expect_true(all(good_holdout))
-})
-
-
-test_that("bad args", {
-  expect_error(spatial_clustering_cv(Smithsonian, coords = NULL))
-  expect_error(
-    spatial_clustering_cv(Smithsonian, coords = c(Species, Sepal.Width))
-  )
-  expect_snapshot(
-    spatial_clustering_cv(
-      Smithsonian,
-      coords = c(latitude, longitude),
-      v = "a"
-    ),
-    error = TRUE
-  )
-  expect_snapshot(
-    spatial_clustering_cv(
-      Smithsonian,
-      coords = c(latitude, longitude),
-      v = c(5, 10)
-    ),
-    error = TRUE
-  )
-  expect_snapshot(
-    spatial_clustering_cv(
-      Smithsonian,
-      coords = c(latitude, longitude),
-      v = 100
-    ),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    spatial_clustering_cv(Smithsonian, name),
-    error = TRUE
-  )
-
-})
-
-test_that("can pass the dots to kmeans", {
-  expect_error(
-    spatial_clustering_cv(
-      Smithsonian,
-      coords = c(latitude, longitude),
-      v = 2,
-      algorithm = "MacQueen"
-    ),
-    NA
-  )
-})
-
-test_that("using sf", {
-
+test_that("repeats", {
   set.seed(11)
   rs1 <- spatial_clustering_cv(
     Smithsonian_sf,
-    v = 2
+    v = 2,
+    repeats = 2
   )
   sizes1 <- dim_rset(rs1)
 
@@ -149,13 +35,108 @@ test_that("using sf", {
     }
   )
   expect_true(all(good_holdout))
+})
 
-  # This tests to ensure that _our_ warning happens on all platforms:
-  set.seed(123)
-  expect_warning(
-    spatial_clustering_cv(Smithsonian_sf, coords = c(latitude, longitude)),
-    "`coords` is ignored when providing `sf` objects to `data`."
+test_that("using hclust", {
+  set.seed(11)
+  rs1 <- spatial_clustering_cv(
+    Smithsonian_sf,
+    v = 2,
+    cluster_function = "hclust"
   )
+  sizes1 <- dim_rset(rs1)
+
+  expect_true(all(sizes1$analysis + sizes1$assessment == 20))
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
+      isTRUE(all.equal(x$data, Smithsonian_sf))
+    }
+  )
+  expect_true(all(same_data))
+
+  good_holdout <- map_lgl(
+    rs1$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+})
+
+
+test_that("bad args", {
+  expect_snapshot(
+    spatial_clustering_cv(Smithsonian),
+    error = TRUE
+  )
+  expect_snapshot(
+    spatial_clustering_cv(
+      Smithsonian_sf,
+      v = "a"
+    ),
+    error = TRUE
+  )
+  expect_snapshot(
+    spatial_clustering_cv(
+      Smithsonian_sf,
+      v = c(5, 10)
+    ),
+    error = TRUE
+  )
+  expect_snapshot(
+    spatial_clustering_cv(
+      Smithsonian_sf,
+      v = 100
+    ),
+    error = TRUE
+  )
+})
+
+test_that("can pass the dots to kmeans", {
+  expect_error(
+    spatial_clustering_cv(
+      Smithsonian_sf,
+      v = 2,
+      algorithm = "MacQueen"
+    ),
+    NA
+  )
+})
+
+test_that("using sf", {
+
+  set.seed(11)
+  rs1 <- spatial_clustering_cv(
+    Smithsonian_sf,
+    v = 2
+  )
+  sizes1 <- dim_rset(rs1)
+
+  set.seed(11)
+  rs2 <- spatial_clustering_cv(
+    Smithsonian_sf,
+    v = 2,
+    cluster_function = "kmeans"
+  )
+  expect_identical(rs1, rs2)
+
+  expect_true(all(sizes1$analysis + sizes1$assessment == 20))
+  same_data <- map_lgl(
+    rs1$splits,
+    function(x) {
+      isTRUE(all.equal(x$data, Smithsonian_sf))
+    }
+  )
+  expect_true(all(same_data))
+
+  good_holdout <- map_lgl(
+    rs1$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
 
   # This tests to ensure that _other_ warnings don't fire on _most_ platforms
   # The default RNG changed in 3.6.0 (skips oldrel-4)
@@ -166,7 +147,7 @@ test_that("using sf", {
   skip_if_not(sf::sf_use_s2())
   set.seed(123)
   expect_snapshot(
-    spatial_clustering_cv(Smithsonian_sf, coords = c(latitude, longitude))
+    spatial_clustering_cv(Smithsonian_sf)
   )
 })
 
@@ -178,29 +159,16 @@ test_that("using custom functions", {
 
   set.seed(11)
   rs1 <- spatial_clustering_cv(
-    Smithsonian,
-    coords = c(latitude, longitude),
+    Smithsonian_sf,
     v = 2
   )
   set.seed(11)
   rs2 <- spatial_clustering_cv(
-    Smithsonian,
-    coords = c(latitude, longitude),
+    Smithsonian_sf,
     v = 2,
     cluster_function = custom_cluster
   )
-  expect_identical(rs1, rs2)
-
-  expect_error(
-    spatial_clustering_cv(
-      Smithsonian,
-      coords = c(latitude, longitude),
-      v = 2,
-      cluster_function = custom_cluster,
-      algorithm = "MacQueen"
-    ),
-    NA
-  )
+  expect_identical(rs1$splits, rs2$splits)
 
   expect_error(
     spatial_clustering_cv(
@@ -247,15 +215,15 @@ test_that("printing", {
   skip_if_not(getRversion() >= numeric_version("3.6.0"))
   set.seed(123)
   expect_snapshot_output(
-    spatial_clustering_cv(Smithsonian,
-      coords = c(latitude, longitude),
+    spatial_clustering_cv(
+      Smithsonian_sf,
       v = 2
     )
   )
 })
 
 test_that("rsplit labels", {
-  rs <- spatial_clustering_cv(Smithsonian, coords = c(latitude, longitude), v = 2)
+  rs <- spatial_clustering_cv(Smithsonian_sf, v = 2)
   all_labs <- map_df(rs$splits, labels)
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)


### PR DESCRIPTION
This fixes #120 and fixes #104 by wrapping `rsample::clustering_cv()`. 

There's three big (breaking) changes here that I'm aware of:

1. `spatial_clustering_cv()` no longer handles non-`sf` objects, because I think they'd be better handled via `rsample::clustering_cv()`.
2. Distances are now calculated between edges, not centroids, of non-point geometries. This is how the rest of the package works, and it makes the most sense to me; if you have polygons which touch, you'd probably assume their data has some amount of spatial relationship, regardless of where the midpoint of each polygon is.
3. Because the new `distance_function` argument is now a function by default, and gets assigned as an attribute to the resulting rset, the `distance_function` attribute winds up having a somewhat complex environment, which is non-intuitive:

``` r
library(spatialsample)

clust <- spatial_clustering_cv(boston_canopy, v = 2)
lobstr::obj_sizes(
  boston_canopy,
  environment(attr(clust, "distance_function"))
)
#> * 984.07 kB
#> *  60.74 kB

ls(environment(attr(clust, "distance_function")))
#>  [1] "buffer"            "cluster_function"  "cv_att"           
#>  [4] "data"              "distance_function" "n"                
#>  [7] "radius"            "repeats"           "rset"             
#> [10] "v"
```

<sup>Created on 2022-12-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I'm not sure if there's a good way to "zero out" that environment, so that we aren't accidentally dragging extra data along.

Otherwise, this function _should_ work the same as it always has. 