### PR TITLE
Skip s2-requiring-tests if no s2

### DIFF
--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -4,6 +4,7 @@ skip_if_not_installed("vdiffr")
 data(ames, package = "modeldata")
 
 test_that("autoplot is stable", {
+  skip_if_not(sf::sf_use_s2())
 
   ames_sf <- sf::st_as_sf(ames, coords = c("Longitude", "Latitude"), crs = 4326)
   set.seed(123)

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -46,6 +46,7 @@ test_that("random assignment", {
 })
 
 test_that("repeated", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
   rs2 <- spatial_block_cv(ames_sf, repeats = 2)
 
@@ -173,6 +174,7 @@ test_that("systematic assignment -- continuous", {
 })
 
 test_that("polygons are only assigned one fold", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
 
   rs1 <- spatial_block_cv(boston_canopy, method = "continuous")
@@ -209,6 +211,7 @@ test_that("polygons are only assigned one fold", {
 })
 
 test_that("blocks are filtered based on centroids", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(123)
   rs1 <- spatial_block_cv(boston_canopy, v = 18, cellsize = 15000)
   expect_true(

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -11,6 +11,7 @@ Smithsonian_sf <- sf::st_as_sf(
 )
 
 test_that("repeats", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
   rs1 <- spatial_clustering_cv(
     Smithsonian_sf,
@@ -38,6 +39,7 @@ test_that("repeats", {
 })
 
 test_that("using hclust", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
   rs1 <- spatial_clustering_cv(
     Smithsonian_sf,
@@ -94,6 +96,7 @@ test_that("bad args", {
 })
 
 test_that("can pass the dots to kmeans", {
+  skip_if_not(sf::sf_use_s2())
   expect_error(
     spatial_clustering_cv(
       Smithsonian_sf,
@@ -105,7 +108,7 @@ test_that("can pass the dots to kmeans", {
 })
 
 test_that("using sf", {
-
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
   rs1 <- spatial_clustering_cv(
     Smithsonian_sf,
@@ -152,6 +155,7 @@ test_that("using sf", {
 })
 
 test_that("using custom functions", {
+  skip_if_not(sf::sf_use_s2())
   custom_cluster <- function(dists, v, ...) {
     clusters <- kmeans(dists, centers = v, ...)
     letters[clusters$cluster]
@@ -182,6 +186,7 @@ test_that("using custom functions", {
 })
 
 test_that("polygons are only assigned one fold", {
+  skip_if_not(sf::sf_use_s2())
   set.seed(11)
 
   rs1 <- spatial_clustering_cv(boston_canopy, cluster_function = "hclust")
@@ -211,6 +216,7 @@ test_that("polygons are only assigned one fold", {
 })
 
 test_that("printing", {
+  skip_if_not(sf::sf_use_s2())
   # The default RNG changed in 3.6.0
   skip_if_not(getRversion() >= numeric_version("3.6.0"))
   set.seed(123)
@@ -223,6 +229,7 @@ test_that("printing", {
 })
 
 test_that("rsplit labels", {
+  skip_if_not(sf::sf_use_s2())
   rs <- spatial_clustering_cv(Smithsonian_sf, v = 2)
   all_labs <- map_df(rs$splits, labels)
   original_id <- rs[, grepl("^id", names(rs))]


### PR DESCRIPTION
This PR fixes an issue on winbuilder, macbuilder, and other CRAN-like build servers (R-Universe) caused by there being no s2 available for sf at the moment. We skip most tests if s2 isn't available anyway, as this package only handles geographic coordinates properly if s2 is around, so this mostly just makes us consistent.

This does _not_ fix the oldrel issue related to a purrr DLL. I have no idea what that's about.