### PR TITLE
Remove data.frame from input type documentation in spatial_clustering_cv()

### DIFF
--- a/R/spatial_clustering_cv.R
+++ b/R/spatial_clustering_cv.R
@@ -34,8 +34,8 @@
 #' `nrow(data)`, with each element of the vector corresponding to the matching
 #' row of the data frame.
 #'
-#' @param data A data frame or an `sf` object (often from [sf::read_sf()]
-#' or [sf::st_as_sf()]), to split into folds.
+#' @param data An `sf` object (often from [sf::read_sf()]
+#' or [sf::st_as_sf()]) to split into folds.
 #' @inheritParams buffer_indices
 #' @inheritParams rsample::clustering_cv
 #' @param distance_function Which function should be used for distance

--- a/man/spatial_clustering_cv.Rd
+++ b/man/spatial_clustering_cv.Rd
@@ -16,8 +16,8 @@ spatial_clustering_cv(
 )
 }
 \arguments{
-\item{data}{A data frame or an \code{sf} object (often from \code{\link[sf:st_read]{sf::read_sf()}}
-or \code{\link[sf:st_as_sf]{sf::st_as_sf()}}), to split into folds.}
+\item{data}{An \code{sf} object (often from \code{\link[sf:st_read]{sf::read_sf()}}
+or \code{\link[sf:st_as_sf]{sf::st_as_sf()}}) to split into folds.}
 
 \item{v}{The number of partitions of the data set.}
 


### PR DESCRIPTION
This is a bit of cleanup post #126, updating the documentation to remove `data.frame` as an input class for `spatial_clustering_cv()` now that spatialsample is only focused on spatial data.

Fixes #129  