### PR TITLE
Fix test for dplyr 1.1.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -185,7 +185,7 @@ test_that("left_join() can keep rset class if rset structure is intact", {
 test_that("left_join() can lose rset class if rows are added", {
   for (x in rset_subclasses) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(left_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(left_join(x, y, by = "id", multiple = "all"))
   }
 })
 
@@ -207,7 +207,7 @@ test_that("right_join() can keep rset class if rset structure is intact", {
 test_that("right_join() can lose rset class if rows are added", {
   for (x in rset_subclasses) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(right_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(right_join(x, y, by = "id", multiple = "all"))
   }
 })
 


### PR DESCRIPTION
This fixes a bunch of new WARNINGs following the release of dplyr 1.1.0.

It also adds a trigger to the R-CMD-check workflow that will let me run checks on GHA without needing to use my own machine.