### PR TITLE
Swap author order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,10 @@ Package: spatialsample
 Title: Spatial Resampling Infrastructure
 Version: 0.3.0.9000
 Authors@R: c(
-    person("Julia", "Silge", , "julia.silge@rstudio.com", role = c("aut"),
-           comment = c(ORCID = "0000-0002-3671-836X")),
     person("Michael", "Mahoney", , "mike.mahoney.218@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2402-304X")),
+    person("Julia", "Silge", , "julia.silge@rstudio.com", role = c("aut"),
+           comment = c(ORCID = "0000-0002-3671-836X")),    
     person("RStudio", role = c("cph", "fnd"))
   )
 Description: Functions and classes for spatial resampling to use with the


### PR DESCRIPTION
From email with Julia, and to mirror https://github.com/tidymodels/rsample/pull/359 , this PR swaps the author order so that when running `citation("spatialsample")` for the package I get listed as first author.