### PR TITLE
Update snaps for new pillar

### DIFF
--- a/tests/testthat/_snaps/buffer.md
+++ b/tests/testthat/_snaps/buffer.md
@@ -71,7 +71,7 @@
        8 <split [663/7]> Fold008
        9 <split [663/7]> Fold009
       10 <split [665/7]> Fold010
-      # ... with 672 more rows
+      # i 672 more rows
 
 ---
 
@@ -97,7 +97,7 @@
        8 <split [2617/136]> Resample08
        9 <split [2764/150]> Resample09
       10 <split [2501/324]> Resample10
-      # ... with 18 more rows
+      # i 18 more rows
 
 ---
 

--- a/tests/testthat/_snaps/spatial_block_cv.md
+++ b/tests/testthat/_snaps/spatial_block_cv.md
@@ -121,7 +121,7 @@
        8 <split [2736/194]> Fold08
        9 <split [2919/11]>  Fold09
       10 <split [2855/75]>  Fold10
-      # ... with 17 more rows
+      # i 17 more rows
 
 ---
 
@@ -146,7 +146,7 @@
        8 <split [2928/2]>   Fold08
        9 <split [2929/1]>   Fold09
       10 <split [2923/7]>   Fold10
-      # ... with 44 more rows
+      # i 44 more rows
 
 ---
 
@@ -196,7 +196,7 @@
        8 <split [2854/76]>  Fold08
        9 <split [2927/3]>   Fold09
       10 <split [2870/60]>  Fold10
-      # ... with 44 more rows
+      # i 44 more rows
 
 ---
 

--- a/tests/testthat/_snaps/spatial_vfold_cv.md
+++ b/tests/testthat/_snaps/spatial_vfold_cv.md
@@ -130,7 +130,7 @@
        8 <split [2691/239]> Resample08
        9 <split [2779/151]> Resample09
       10 <split [2748/182]> Resample10
-      # ... with 18 more rows
+      # i 18 more rows
 
 ---
 
@@ -155,7 +155,7 @@
        8 <split [681/1]> Fold008
        9 <split [681/1]> Fold009
       10 <split [681/1]> Fold010
-      # ... with 672 more rows
+      # i 672 more rows
 
 ---
 


### PR DESCRIPTION
A new pillar update broke snapshots again; see also #106 & #111 / #112. Think this is all the update required.