### PR TITLE
Use map with bind_rows rather than map_dfr()

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -46,17 +46,18 @@ autoplot.spatial_rset <- function(object, ..., alpha = 0.6) {
   .fold. <- .facet. <- NULL
 
   object <- if (sum(bool_id_columns) == 1) {
-    purrr::map2_dfr(
+    purrr::map2(
       object$splits,
       object$id,
       ~ cbind(assessment(.x), .fold. = .y)
     )
   } else {
-    purrr::pmap_dfr(
+    purrr::pmap(
       object[grepl("splits", names(object)) | bool_id_columns],
       ~ cbind(assessment(..1), .facet. = ..2, .fold. = ..3)
     )
   }
+  object <- dplyr::bind_rows(object)
 
   p <- ggplot2::ggplot(
     data = object,

--- a/tests/testthat/test-spatial_block_cv.R
+++ b/tests/testthat/test-spatial_block_cv.R
@@ -296,7 +296,7 @@ test_that("rsplit labels", {
   skip_if_not(sf::sf_use_s2())
   set.seed(123)
   rs <- spatial_block_cv(ames_sf, v = 2)
-  all_labs <- map_df(rs$splits, labels)
+  all_labs <- dplyr::bind_rows(purrr::map(rs$splits, labels))
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)
 })

--- a/tests/testthat/test-spatial_clustering_cv.R
+++ b/tests/testthat/test-spatial_clustering_cv.R
@@ -230,7 +230,7 @@ test_that("printing", {
 test_that("rsplit labels", {
   skip_if_not(sf::sf_use_s2())
   rs <- spatial_clustering_cv(Smithsonian_sf, v = 2)
-  all_labs <- map_df(rs$splits, labels)
+  all_labs <- dplyr::bind_rows(purrr::map(rs$splits, labels))
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)
 })

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -236,13 +236,13 @@ test_that("rsplit labels", {
   skip_if_not(sf::sf_use_s2())
   set.seed(123)
   rs <- spatial_buffer_vfold_cv(ames_sf, v = 2, buffer = NULL, radius = NULL)
-  all_labs <- map_df(rs$splits, labels)
+  all_labs <- dplyr::bind_rows(purrr::map(rs$splits, labels))
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)
 
   set.seed(123)
   rs <- spatial_leave_location_out_cv(ames_sf, Neighborhood, v = 2)
-  all_labs <- map_df(rs$splits, labels)
+  all_labs <- dplyr::bind_rows(purrr::map(rs$splits, labels))
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)
 })


### PR DESCRIPTION
Inspired by https://github.com/tidymodels/rsample/pull/423 :smile: 

This PR uses `dplyr::bind_rows()` in order to preserve the class of the input data (namely, to keep our data as sf objects); unfortunately `purrr::list_rbind()` casts to a pure data.frame.