### PR TITLE
Show top-level function in error message

### DIFF
--- a/R/spatial_block_cv.R
+++ b/R/spatial_block_cv.R
@@ -262,10 +262,13 @@ generate_folds_from_blocks <- function(data, centroids, grid_blocks, v, n, radiu
   # forward
   n_indices <- sum(vapply(indices, length, numeric(1)))
   if (n_indices > nrow(data)) {
-    rlang::abort(c(
-      "Some observations fell exactly on block boundaries, meaning they were assigned to multiple assessment sets unexpectedly.",
-      i = "Try setting a different `expand_bbox` value, an `offset`, or use a different number of folds."
-    ))
+    rlang::abort(
+      c(
+        "Some observations fell exactly on block boundaries, meaning they were assigned to multiple assessment sets unexpectedly.",
+        i = "Try setting a different `expand_bbox` value, an `offset`, or use a different number of folds."
+      ),
+      call = rlang::caller_env(n = 3)
+    )
   }
 
   if (is.null(radius) && is.null(buffer)) {


### PR DESCRIPTION
Current HEAD:
``` r
library(spatialsample)
drought_sf <- sf::st_as_sf(
  expand.grid(
    x = seq(995494, 1018714, 430),
    y = seq(1019422, by = 430, length.out = 55)
  ),
  coords = c("x", "y"),
  crs = 7760
)
spatial_block_cv(drought_sf, expand_bbox = 0)
#> Error in `generate_folds_from_blocks()` at spatialsample/R/spatial_block_cv.R:204:2:
#> ! Some observations fell exactly on block boundaries, meaning they were assigned to multiple assessment sets unexpectedly.
#> ℹ Try setting a different `expand_bbox` value, an `offset`, or use a different number of folds.
#> Backtrace:
#>     ▆
#>  1. └─spatialsample::spatial_block_cv(drought_sf, expand_bbox = 0)
#>  2.   └─spatialsample (local) block_fun(method) at spatialsample/R/spatial_block_cv.R:129:4
#>  3.     └─spatialsample:::random_block_cv(...) at spatialsample/R/spatial_block_cv.R:106:4
#>  4.       └─spatialsample:::generate_folds_from_blocks(data, centroids, grid_blocks, v, n, radius, buffer) at spatialsample/R/spatial_block_cv.R:204:2
#>  5.         └─rlang::abort(...) at spatialsample/R/spatial_block_cv.R:264:4
```

<sup>Created on 2023-11-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This PR:
``` r
library(spatialsample)
drought_sf <- sf::st_as_sf(
  expand.grid(
    x = seq(995494, 1018714, 430),
    y = seq(1019422, by = 430, length.out = 55)
  ),
  coords = c("x", "y"),
  crs = 7760
)
spatial_block_cv(drought_sf, expand_bbox = 0)
#> Error in `spatial_block_cv()`:
#> ! Some observations fell exactly on block boundaries, meaning they were assigned to multiple assessment sets unexpectedly.
#> ℹ Try setting a different `expand_bbox` value, an `offset`, or use a different number of folds.
#> Backtrace:
#>     ▆
#>  1. └─spatialsample::spatial_block_cv(drought_sf, expand_bbox = 0)
#>  2.   └─spatialsample (local) block_fun(method) at spatialsample/R/spatial_block_cv.R:129:4
#>  3.     └─spatialsample:::random_block_cv(...) at spatialsample/R/spatial_block_cv.R:106:4
#>  4.       └─spatialsample:::generate_folds_from_blocks(...) at spatialsample/R/spatial_block_cv.R:205:2
#>  5.         └─rlang::abort(...) at spatialsample/R/spatial_block_cv.R:265:4
```

<sup>Created on 2023-11-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>