### PR TITLE
Updates for current rsample

### DIFF
--- a/R/spatial_vfold_cv.R
+++ b/R/spatial_vfold_cv.R
@@ -61,21 +61,25 @@
 #' ames_neighborhoods <- spatial_leave_location_out_cv(ames_sf, Neighborhood)
 #'
 #' @export
-spatial_buffer_vfold_cv <- function(data,
-                                    radius,
-                                    buffer,
-                                    v = 10,
-                                    repeats = 1,
-                                    strata = NULL,
-                                    breaks = 4,
-                                    pool = 0.1,
-                                    ...) {
+spatial_buffer_vfold_cv <- function(
+  data,
+  radius,
+  buffer,
+  v = 10,
+  repeats = 1,
+  strata = NULL,
+  breaks = 4,
+  pool = 0.1,
+  ...
+) {
   standard_checks(data, "`spatial_buffer_vfold_cv()`")
 
   if (missing(radius) || missing(buffer)) {
     use_vfold <- NULL
     if (missing(radius) && missing(buffer)) {
-      use_vfold <- c(i = "Or use `rsample::vfold_cv() to use a non-spatial V-fold.")
+      use_vfold <- c(
+        i = "Or use `rsample::vfold_cv() to use a non-spatial V-fold."
+      )
     }
     rlang::abort(
       c(
@@ -88,15 +92,6 @@ spatial_buffer_vfold_cv <- function(data,
 
   n <- nrow(data)
   v <- check_v(v, n, "rows")
-  if (v == n && repeats > 1) {
-    rlang::abort(
-      c(
-        "Repeated cross-validation doesn't make sense when performing leave-one-out cross-validation.",
-        i = "Set `v` to a lower value.",
-        i = "Or set `repeats = 1`."
-      )
-    )
-  }
 
   rset <- rsample::vfold_cv(
     data = data,
@@ -113,7 +108,9 @@ spatial_buffer_vfold_cv <- function(data,
     if (length(strata) == 0) strata <- NULL
   }
 
-  if (!is.null(strata)) names(strata) <- NULL
+  if (!is.null(strata)) {
+    names(strata) <- NULL
+  }
   cv_att <- list(
     v = v,
     repeats = repeats,
@@ -151,13 +148,15 @@ spatial_buffer_vfold_cv <- function(data,
 #' @rdname spatial_vfold
 #'
 #' @export
-spatial_leave_location_out_cv <- function(data,
-                                          group,
-                                          v = NULL,
-                                          radius = NULL,
-                                          buffer = NULL,
-                                          ...,
-                                          repeats = 1) {
+spatial_leave_location_out_cv <- function(
+  data,
+  group,
+  v = NULL,
+  radius = NULL,
+  buffer = NULL,
+  ...,
+  repeats = 1
+) {
   if (!missing(group)) {
     group <- tidyselect::eval_select(rlang::enquo(group), data)
   }
@@ -165,7 +164,9 @@ spatial_leave_location_out_cv <- function(data,
   if (missing(group) || length(group) == 0) {
     group <- NULL
   } else {
-    if (is.null(v)) v <- length(unique(data[[group]]))
+    if (is.null(v)) {
+      v <- length(unique(data[[group]]))
+    }
     v <- check_v(v, length(unique(data[[group]])), "locations")
     n <- nrow(data)
     if (v == n && repeats > 1) {
@@ -215,15 +216,17 @@ spatial_leave_location_out_cv <- function(data,
   )
 }
 
-posthoc_buffer_rset <- function(data,
-                                rset,
-                                rsplit_class,
-                                rset_class,
-                                radius,
-                                buffer,
-                                n,
-                                v,
-                                cv_att) {
+posthoc_buffer_rset <- function(
+  data,
+  rset,
+  rsplit_class,
+  rset_class,
+  radius,
+  buffer,
+  n,
+  v,
+  cv_att
+) {
   # This basically undoes everything post-`split_unnamed` for us
   # so we're back to an unnamed list of assessment-set indices
   indices <- purrr::map(rset$splits, as.integer, "assessment")

--- a/tests/testthat/_snaps/autoplot/block-plots-with-grid.svg
+++ b/tests/testthat/_snaps/autoplot/block-plots-with-grid.svg
@@ -3067,34 +3067,34 @@
 <text x='659.45' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='659.45' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='220.06' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-opacity: 0.60; fill: #F8766D; fill-opacity: 0.60;' />
-<rect x='660.16' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='237.34' r='1.95' style='stroke-width: 0.71; stroke: #D89000; stroke-opacity: 0.60; fill: #D89000; fill-opacity: 0.60;' />
-<rect x='660.16' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='245.98' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='254.62' r='1.95' style='stroke-width: 0.71; stroke: #A3A500; stroke-opacity: 0.60; fill: #A3A500; fill-opacity: 0.60;' />
-<rect x='660.16' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='263.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='271.90' r='1.95' style='stroke-width: 0.71; stroke: #39B600; stroke-opacity: 0.60; fill: #39B600; fill-opacity: 0.60;' />
-<rect x='660.16' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='280.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='289.18' r='1.95' style='stroke-width: 0.71; stroke: #00BF7D; stroke-opacity: 0.60; fill: #00BF7D; fill-opacity: 0.60;' />
-<rect x='660.16' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='297.82' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='306.46' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; stroke-opacity: 0.60; fill: #00BFC4; fill-opacity: 0.60;' />
-<rect x='660.16' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='315.10' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='323.74' r='1.95' style='stroke-width: 0.71; stroke: #00B0F6; stroke-opacity: 0.60; fill: #00B0F6; fill-opacity: 0.60;' />
-<rect x='660.16' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='332.38' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='341.02' r='1.95' style='stroke-width: 0.71; stroke: #9590FF; stroke-opacity: 0.60; fill: #9590FF; fill-opacity: 0.60;' />
-<rect x='660.16' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='349.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='358.30' r='1.95' style='stroke-width: 0.71; stroke: #E76BF3; stroke-opacity: 0.60; fill: #E76BF3; fill-opacity: 0.60;' />
-<rect x='660.16' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='659.45' y='366.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='668.09' cy='375.58' r='1.95' style='stroke-width: 0.71; stroke: #FF62BC; stroke-opacity: 0.60; fill: #FF62BC; fill-opacity: 0.60;' />
-<rect x='660.16' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='659.73' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
 <text x='682.21' y='223.09' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold01</text>
 <text x='682.21' y='240.37' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold02</text>
 <text x='682.21' y='257.65' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold03</text>

--- a/tests/testthat/_snaps/autoplot/buffered-rsample-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-rsample-plot.svg
@@ -824,11 +824,11 @@
 <rect x='643.81' y='256.57' width='70.71' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='643.81' y='265.28' style='font-size: 11.00px; font-family: sans;' textLength='27.52px' lengthAdjust='spacingAndGlyphs'>Class</text>
 <rect x='643.81' y='271.90' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='272.61' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='644.10' y='272.19' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='643.81' y='289.18' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='289.89' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38; fill-opacity: 0.60;' />
+<rect x='644.10' y='289.47' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BA38; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38; fill-opacity: 0.60;' />
 <rect x='643.81' y='306.46' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='307.17' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF; fill-opacity: 0.60;' />
+<rect x='644.10' y='306.75' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #619CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF; fill-opacity: 0.60;' />
 <text x='666.57' y='283.57' style='font-size: 8.80px; font-family: sans;' textLength='32.78px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
 <text x='666.57' y='300.85' style='font-size: 8.80px; font-family: sans;' textLength='47.95px' lengthAdjust='spacingAndGlyphs'>Assessment</text>
 <text x='666.57' y='318.13' style='font-size: 8.80px; font-family: sans;' textLength='23.48px' lengthAdjust='spacingAndGlyphs'>Buffer</text>

--- a/tests/testthat/_snaps/autoplot/buffered-rset-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-rset-plot.svg
@@ -885,35 +885,35 @@
 <rect x='664.85' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
-<rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='665.14' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
-<rect x='665.56' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
+<rect x='665.14' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='245.98' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
-<rect x='665.56' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
+<rect x='665.14' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='263.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
-<rect x='665.56' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
+<rect x='665.14' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='280.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
-<rect x='665.56' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
+<rect x='665.14' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='297.82' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
-<rect x='665.56' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
+<rect x='665.14' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='315.10' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
-<rect x='665.56' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
+<rect x='665.14' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='332.38' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
-<rect x='665.56' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
+<rect x='665.14' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='349.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
-<rect x='665.56' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
+<rect x='665.14' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='366.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
-<rect x='665.56' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
+<rect x='665.14' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
 <text x='687.61' y='223.09' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold01</text>
 <text x='687.61' y='240.37' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold02</text>
 <text x='687.61' y='257.65' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold03</text>

--- a/tests/testthat/_snaps/autoplot/buffered-vfold-plot.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-vfold-plot.svg
@@ -824,25 +824,25 @@
 <rect x='664.85' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='665.14' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='664.85' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
+<rect x='665.14' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
 <rect x='664.85' y='245.98' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
+<rect x='665.14' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
 <rect x='664.85' y='263.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
+<rect x='665.14' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
 <rect x='664.85' y='280.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
+<rect x='665.14' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
 <rect x='664.85' y='297.82' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
+<rect x='665.14' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
 <rect x='664.85' y='315.10' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
+<rect x='665.14' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
 <rect x='664.85' y='332.38' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
+<rect x='665.14' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
 <rect x='664.85' y='349.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
+<rect x='665.14' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
 <rect x='664.85' y='366.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
+<rect x='665.14' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
 <text x='687.61' y='223.09' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold01</text>
 <text x='687.61' y='240.37' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold02</text>
 <text x='687.61' y='257.65' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold03</text>

--- a/tests/testthat/_snaps/autoplot/buffered-vfold-split.svg
+++ b/tests/testthat/_snaps/autoplot/buffered-vfold-split.svg
@@ -824,11 +824,11 @@
 <rect x='643.81' y='256.57' width='70.71' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='643.81' y='265.28' style='font-size: 11.00px; font-family: sans;' textLength='27.52px' lengthAdjust='spacingAndGlyphs'>Class</text>
 <rect x='643.81' y='271.90' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='272.61' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='644.10' y='272.19' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
 <rect x='643.81' y='289.18' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='289.89' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38; fill-opacity: 0.60;' />
+<rect x='644.10' y='289.47' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BA38; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38; fill-opacity: 0.60;' />
 <rect x='643.81' y='306.46' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='644.52' y='307.17' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF; fill-opacity: 0.60;' />
+<rect x='644.10' y='306.75' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #619CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF; fill-opacity: 0.60;' />
 <text x='666.57' y='283.57' style='font-size: 8.80px; font-family: sans;' textLength='32.78px' lengthAdjust='spacingAndGlyphs'>Analysis</text>
 <text x='666.57' y='300.85' style='font-size: 8.80px; font-family: sans;' textLength='47.95px' lengthAdjust='spacingAndGlyphs'>Assessment</text>
 <text x='666.57' y='318.13' style='font-size: 8.80px; font-family: sans;' textLength='23.48px' lengthAdjust='spacingAndGlyphs'>Buffer</text>

--- a/tests/testthat/_snaps/autoplot/expand-bbox.svg
+++ b/tests/testthat/_snaps/autoplot/expand-bbox.svg
@@ -832,17 +832,17 @@
 <rect x='434.53' y='247.93' width='44.77' height='84.45' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='434.53' y='256.64' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='434.53' y='263.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='435.24' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
-<rect x='435.24' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='434.81' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='434.81' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='434.53' y='280.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='435.24' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt; stroke-linejoin: miter; fill: #7CAE00; fill-opacity: 0.60;' />
-<rect x='435.24' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #7CAE00; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='434.81' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #7CAE00; stroke-linecap: butt; stroke-linejoin: miter; fill: #7CAE00; fill-opacity: 0.60;' />
+<rect x='434.81' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #7CAE00; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='434.53' y='297.82' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='435.24' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
-<rect x='435.24' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='434.81' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
+<rect x='434.81' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='434.53' y='315.10' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='435.24' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C77CFF; fill-opacity: 0.60;' />
-<rect x='435.24' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #C77CFF; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='434.81' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #C77CFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C77CFF; fill-opacity: 0.60;' />
+<rect x='434.81' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #C77CFF; stroke-linecap: butt; stroke-linejoin: miter;' />
 <text x='457.29' y='274.93' style='font-size: 8.80px; font-family: sans;' textLength='22.01px' lengthAdjust='spacingAndGlyphs'>Fold1</text>
 <text x='457.29' y='292.21' style='font-size: 8.80px; font-family: sans;' textLength='22.01px' lengthAdjust='spacingAndGlyphs'>Fold2</text>
 <text x='457.29' y='309.49' style='font-size: 8.80px; font-family: sans;' textLength='22.01px' lengthAdjust='spacingAndGlyphs'>Fold3</text>

--- a/tests/testthat/_snaps/autoplot/repeated-block-cv.svg
+++ b/tests/testthat/_snaps/autoplot/repeated-block-cv.svg
@@ -1745,35 +1745,35 @@
 <rect x='664.85' y='204.42' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='664.85' y='213.13' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='219.75' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='220.46' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
-<rect x='665.56' y='220.46' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='220.03' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='665.14' y='220.03' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='237.03' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='237.74' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
-<rect x='665.56' y='237.74' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='237.31' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
+<rect x='665.14' y='237.31' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='254.31' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='255.02' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
-<rect x='665.56' y='255.02' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='254.59' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
+<rect x='665.14' y='254.59' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='271.59' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='272.30' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
-<rect x='665.56' y='272.30' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='271.87' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
+<rect x='665.14' y='271.87' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='288.87' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='289.58' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
-<rect x='665.56' y='289.58' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='289.15' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
+<rect x='665.14' y='289.15' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='306.15' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='306.86' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
-<rect x='665.56' y='306.86' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='306.43' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
+<rect x='665.14' y='306.43' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='323.43' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='324.14' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
-<rect x='665.56' y='324.14' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='323.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
+<rect x='665.14' y='323.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='340.71' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='341.42' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
-<rect x='665.56' y='341.42' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='340.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
+<rect x='665.14' y='340.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='357.99' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='358.70' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
-<rect x='665.56' y='358.70' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='358.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
+<rect x='665.14' y='358.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='375.27' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='375.98' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
-<rect x='665.56' y='375.98' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='375.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
+<rect x='665.14' y='375.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
 <text x='687.61' y='231.42' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold01</text>
 <text x='687.61' y='248.70' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold02</text>
 <text x='687.61' y='265.98' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold03</text>

--- a/tests/testthat/_snaps/autoplot/snake-flips-rows-the-right-way.svg
+++ b/tests/testthat/_snaps/autoplot/snake-flips-rows-the-right-way.svg
@@ -1054,35 +1054,35 @@
 <rect x='664.85' y='196.09' width='49.67' height='188.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='664.85' y='204.80' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>Fold</text>
 <rect x='664.85' y='211.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
-<rect x='665.56' y='212.13' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D; fill-opacity: 0.60;' />
+<rect x='665.14' y='211.71' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='228.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
-<rect x='665.56' y='229.41' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter; fill: #D89000; fill-opacity: 0.60;' />
+<rect x='665.14' y='228.99' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #D89000; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='245.98' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
-<rect x='665.56' y='246.69' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter; fill: #A3A500; fill-opacity: 0.60;' />
+<rect x='665.14' y='246.27' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #A3A500; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='263.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
-<rect x='665.56' y='263.97' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter; fill: #39B600; fill-opacity: 0.60;' />
+<rect x='665.14' y='263.55' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #39B600; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='280.54' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
-<rect x='665.56' y='281.25' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BF7D; fill-opacity: 0.60;' />
+<rect x='665.14' y='280.83' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BF7D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='297.82' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
-<rect x='665.56' y='298.53' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4; fill-opacity: 0.60;' />
+<rect x='665.14' y='298.11' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='315.10' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
-<rect x='665.56' y='315.81' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter; fill: #00B0F6; fill-opacity: 0.60;' />
+<rect x='665.14' y='315.39' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00B0F6; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='332.38' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
-<rect x='665.56' y='333.09' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #9590FF; fill-opacity: 0.60;' />
+<rect x='665.14' y='332.67' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #9590FF; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='349.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
-<rect x='665.56' y='350.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter; fill: #E76BF3; fill-opacity: 0.60;' />
+<rect x='665.14' y='349.95' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #E76BF3; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='664.85' y='366.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='665.56' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
-<rect x='665.56' y='367.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='665.14' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF62BC; fill-opacity: 0.60;' />
+<rect x='665.14' y='367.23' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #FF62BC; stroke-linecap: butt; stroke-linejoin: miter;' />
 <text x='687.61' y='223.09' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold01</text>
 <text x='687.61' y='240.37' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold02</text>
 <text x='687.61' y='257.65' style='font-size: 8.80px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>Fold03</text>

--- a/tests/testthat/_snaps/buffer.md
+++ b/tests/testthat/_snaps/buffer.md
@@ -55,23 +55,23 @@
 ---
 
     Code
-      spatial_buffer_vfold_cv(boston_canopy, v = 682, radius = 500, buffer = 500)
+      spatial_buffer_vfold_cv(boston_canopy, v = 681, radius = 500, buffer = 500)
     Output
-      #  682-fold spatial cross-validation 
-      # A tibble: 682 x 2
-         splits          id     
-         <list>          <chr>  
-       1 <split [672/3]> Fold001
-       2 <split [664/7]> Fold002
-       3 <split [663/7]> Fold003
-       4 <split [666/7]> Fold004
-       5 <split [665/7]> Fold005
-       6 <split [671/5]> Fold006
-       7 <split [671/6]> Fold007
-       8 <split [663/7]> Fold008
-       9 <split [663/7]> Fold009
-      10 <split [665/7]> Fold010
-      # i 672 more rows
+      #  681-fold spatial cross-validation 
+      # A tibble: 681 x 2
+         splits           id     
+         <list>           <chr>  
+       1 <split [656/10]> Fold001
+       2 <split [664/7]>  Fold002
+       3 <split [663/7]>  Fold003
+       4 <split [666/7]>  Fold004
+       5 <split [665/7]>  Fold005
+       6 <split [671/5]>  Fold006
+       7 <split [671/6]>  Fold007
+       8 <split [663/7]>  Fold008
+       9 <split [663/7]>  Fold009
+      10 <split [665/7]>  Fold010
+      # i 671 more rows
 
 ---
 

--- a/tests/testthat/_snaps/spatial_vfold_cv.md
+++ b/tests/testthat/_snaps/spatial_vfold_cv.md
@@ -155,28 +155,6 @@
 
 ---
 
-    Code
-      spatial_buffer_vfold_cv(boston_canopy, v = 681, buffer = NULL, radius = NULL,
-        repeats = 2)
-    Output
-      #  681-fold spatial cross-validation 
-      # A tibble: 1,362 x 3
-         splits          id      id2    
-         <list>          <chr>   <chr>  
-       1 <split [680/2]> Repeat1 Fold001
-       2 <split [681/1]> Repeat1 Fold002
-       3 <split [681/1]> Repeat1 Fold003
-       4 <split [681/1]> Repeat1 Fold004
-       5 <split [681/1]> Repeat1 Fold005
-       6 <split [681/1]> Repeat1 Fold006
-       7 <split [681/1]> Repeat1 Fold007
-       8 <split [681/1]> Repeat1 Fold008
-       9 <split [681/1]> Repeat1 Fold009
-      10 <split [681/1]> Repeat1 Fold010
-      # i 1,352 more rows
-
----
-
     Repeated resampling when `v` is 28 would create identical resamples.
 
 # printing

--- a/tests/testthat/_snaps/spatial_vfold_cv.md
+++ b/tests/testthat/_snaps/spatial_vfold_cv.md
@@ -80,7 +80,7 @@
       spatial_leave_location_out_cv(ames)
     Condition
       Error in `rsample::group_vfold_cv()`:
-      ! `group` should be a single character value for the column that will be used for splitting.
+      ! `group` must be a single string, not `NULL`.
 
 ---
 
@@ -97,7 +97,7 @@
       spatial_leave_location_out_cv(ames_sf, v = c(5, 10))
     Condition
       Error in `rsample::group_vfold_cv()`:
-      ! `group` should be a single character value for the column that will be used for splitting.
+      ! `group` must be a single string, not `NULL`.
 
 ---
 
@@ -135,17 +135,13 @@
 ---
 
     Code
-      spatial_buffer_vfold_cv(boston_canopy, v = 683, buffer = NULL, radius = NULL)
-    Condition
-      Warning in `spatial_buffer_vfold_cv()`:
-      Fewer than 683 rows available for sampling
-      i Setting `v` to 682
+      spatial_buffer_vfold_cv(boston_canopy, v = 681, buffer = NULL, radius = NULL)
     Output
-      #  682-fold spatial cross-validation 
-      # A tibble: 682 x 2
+      #  681-fold spatial cross-validation 
+      # A tibble: 681 x 2
          splits          id     
          <list>          <chr>  
-       1 <split [681/1]> Fold001
+       1 <split [680/2]> Fold001
        2 <split [681/1]> Fold002
        3 <split [681/1]> Fold003
        4 <split [681/1]> Fold004
@@ -155,17 +151,33 @@
        8 <split [681/1]> Fold008
        9 <split [681/1]> Fold009
       10 <split [681/1]> Fold010
-      # i 672 more rows
+      # i 671 more rows
 
 ---
 
-    Repeated cross-validation doesn't make sense when performing leave-one-out cross-validation.
-    i Set `v` to a lower value.
-    i Or set `repeats = 1`.
+    Code
+      spatial_buffer_vfold_cv(boston_canopy, v = 681, buffer = NULL, radius = NULL,
+        repeats = 2)
+    Output
+      #  681-fold spatial cross-validation 
+      # A tibble: 1,362 x 3
+         splits          id      id2    
+         <list>          <chr>   <chr>  
+       1 <split [680/2]> Repeat1 Fold001
+       2 <split [681/1]> Repeat1 Fold002
+       3 <split [681/1]> Repeat1 Fold003
+       4 <split [681/1]> Repeat1 Fold004
+       5 <split [681/1]> Repeat1 Fold005
+       6 <split [681/1]> Repeat1 Fold006
+       7 <split [681/1]> Repeat1 Fold007
+       8 <split [681/1]> Repeat1 Fold008
+       9 <split [681/1]> Repeat1 Fold009
+      10 <split [681/1]> Repeat1 Fold010
+      # i 1,352 more rows
 
 ---
 
-    Repeated resampling when `v` is 28 would create identical resamples
+    Repeated resampling when `v` is 28 would create identical resamples.
 
 # printing
 

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -56,7 +56,7 @@ test_that("autoplot is stable", {
   set.seed(123)
   boston_vfold_buffer <- spatial_buffer_vfold_cv(
     boston_canopy,
-    v = 682,
+    v = 681,
     radius = 1,
     buffer = 5000
   )

--- a/tests/testthat/test-buffer.R
+++ b/tests/testthat/test-buffer.R
@@ -248,7 +248,6 @@ test_that("using buffers", {
     )
   )
 
-
   # The default RNG changed in 3.6.0
   skip_if_not(getRversion() >= numeric_version("3.6.0"))
 
@@ -256,7 +255,7 @@ test_that("using buffers", {
   expect_snapshot(
     spatial_buffer_vfold_cv(
       boston_canopy,
-      v = 682,
+      v = 681,
       radius = 500,
       buffer = 500
     )

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -15,7 +15,11 @@ test_that("erroring when no S2", {
     error = TRUE
   )
   expect_snapshot(
-    suppressMessages(spatial_leave_location_out_cv(ames_sf, Neighborhood, buffer = 500)),
+    suppressMessages(spatial_leave_location_out_cv(
+      ames_sf,
+      Neighborhood,
+      buffer = 500
+    )),
     error = TRUE
   )
   sf::sf_use_s2(s2_store)
@@ -185,7 +189,12 @@ test_that("bad args", {
 
   set.seed(123)
   expect_snapshot(
-    spatial_buffer_vfold_cv(ames_sf, v = c(5, 10), buffer = NULL, radius = NULL),
+    spatial_buffer_vfold_cv(
+      ames_sf,
+      v = c(5, 10),
+      buffer = NULL,
+      radius = NULL
+    ),
     error = TRUE
   )
 
@@ -198,14 +207,19 @@ test_that("bad args", {
 
   set.seed(123)
   expect_snapshot(
-    spatial_buffer_vfold_cv(boston_canopy, v = 683, buffer = NULL, radius = NULL)
+    spatial_buffer_vfold_cv(
+      boston_canopy,
+      v = 681,
+      buffer = NULL,
+      radius = NULL
+    )
   )
 
   set.seed(123)
-  expect_snapshot_error(
+  expect_snapshot(
     spatial_buffer_vfold_cv(
       boston_canopy,
-      v = 682,
+      v = 681,
       buffer = NULL,
       radius = NULL,
       repeats = 2

--- a/tests/testthat/test-spatial_vfold_cv.R
+++ b/tests/testthat/test-spatial_vfold_cv.R
@@ -216,17 +216,6 @@ test_that("bad args", {
   )
 
   set.seed(123)
-  expect_snapshot(
-    spatial_buffer_vfold_cv(
-      boston_canopy,
-      v = 681,
-      buffer = NULL,
-      radius = NULL,
-      repeats = 2
-    )
-  )
-
-  set.seed(123)
   expect_snapshot_error(
     spatial_leave_location_out_cv(
       ames_sf,


### PR DESCRIPTION
Closes #166

Some recent-ish changes in rsample are affecting spatialsample: rsample now prohibits LOO and has new type checkers.

The related breakages show up in the revdep tests for testthat, which is supposed to go out in the next week or so. 

This PR removes test failures so that we can submit to CRAN (either after we get the 2-week deadline or, ideally, before testthat goes out).

Do you have bandwidth to look at the changes in the snapshots? I think some of the tests use LOO very intentionally to trigger helpful warnings from spatialsample - which might now be dead code. _Edit:_ I've removed such a piece of dead code, the error when trying to do repeated LOO in `spatial_vfold_cv()`. And I've now seen the `buffering.Rmd` article error because it tries to use LOO for "leave-one-disc-out cross-validation". Taking this as confirmation that there was intent behind some of the LOO usage and pausing here so you can chip in before I do more :D